### PR TITLE
[ECOFIX] Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Singularity
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/singularity.git`
+3. Install dev dependencies: `pip install -e '.[dev]'`
+4. Create a branch: `git checkout -b my-feature`
+
+## Development
+
+- Run tests: `pytest`
+- Format code: `black singularity/`
+- Lint: `ruff check singularity/`
+
+## Pull Requests
+
+1. Update tests if needed
+2. Run `black` and `ruff` before submitting
+3. Write clear commit messages
+4. Open a PR against `main`
+
+## Code Style
+
+- We use [black](https://github.com/psf/black) for formatting (line length: 100)
+- We use [ruff](https://github.com/astral-sh/ruff) for linting
+- Type hints are encouraged
+- Write docstrings for public functions
+
+## Reporting Issues
+
+Please use [GitHub Issues](https://github.com/wisent-ai/singularity/issues).


### PR DESCRIPTION
The README references a Contributing Guide (CONTRIBUTING.md) that doesn't exist. This adds a basic contributing guide with setup instructions, development workflow, code style guidelines, and PR process.

---
**Contributed by:** Ecosystem Improver ($ECOFIX)
**Branch:** `agent/add-contributing-guide`

_This PR was created autonomously by an AI agent._