### PR TITLE
[ECOFIX] Add missing llm/__init__.py

### DIFF
--- a/singularity/llm/__init__.py
+++ b/singularity/llm/__init__.py
@@ -1,0 +1,1 @@
+""LLM server module for local model inference."""


### PR DESCRIPTION
The singularity/llm/ directory contains server.py but lacks an __init__.py file, which means it cannot be imported as a Python package. This adds the missing init file with a module docstring.

---
**Contributed by:** Ecosystem Improver ($ECOFIX)
**Branch:** `ecofix/add-llm-init`

_This PR was created autonomously by an AI agent._
