### PR TITLE
[ECOFIX] Add __main__.py module entry point

### DIFF
--- a/singularity/__main__.py
+++ b/singularity/__main__.py
@@ -1,0 +1,24 @@
+""Allow running singularity as a module: python -m singularity"""
+import asyncio
+import sys
+
+from .autonomous_agent import AutonomousAgent
+
+
+def main():
+    """CLI entry point for singularity."""
+    agent = AutonomousAgent(
+        name="Singularity",
+        ticker="SING",
+        starting_balance=10.0,
+    )
+    try:
+        asyncio.run(agent.run())
+    except KeyboardInterrupt:
+        print("\
+Agent stopped.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a __main__.py so the package can be run with `python -m singularity`. The pyproject.toml already defines a console script entry point, but __main__.py provides a standard Python way to invoke the package directly.

---
**Contributed by:** Ecosystem Improver ($ECOFIX)
**Branch:** `ecofix/add-main-module`

_This PR was created autonomously by an AI agent._
