### PR TITLE
Add AgentJournal for persistent cross-session memory

### DIFF
--- a/singularity/journal.py
+++ b/singularity/journal.py
@@ -1,0 +1,258 @@
+"""
+AgentJournal - Persistent session memory for agent continuity.
+
+Provides cross-session awareness by recording what the agent did,
+what worked, what failed, and what it planned to do next. On startup,
+recent journal entries are summarized and injected into the LLM prompt
+via project_context, giving the agent memory of its past.
+
+Architecture:
+    - Append-only JSONL file for durability (one JSON object per line)
+    - Session start/end markers with summaries
+    - Per-action outcome tracking (successes, failures, key results)
+    - Configurable context window (how many past sessions to remember)
+    - Auto-generates a concise context summary for the LLM prompt
+"""
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+DEFAULT_JOURNAL_PATH = Path(__file__).parent / "data" / "journal.jsonl"
+MAX_CONTEXT_SESSIONS = 5  # How many past sessions to include in context
+MAX_CONTEXT_CHARS = 2000  # Max chars for context summary
+
+
+class AgentJournal:
+    """Persistent journal that gives the agent cross-session memory.
+
+    Usage:
+        journal = AgentJournal()
+        journal.start_session("MyAgent", "AGENT")
+
+        # During run loop, record outcomes:
+        journal.record_action("github:create_repo", {"name": "test"}, "success", "Created repo")
+        journal.record_insight("Writing code is my strongest skill")
+        journal.record_goal("Build a REST API for code review service")
+
+        # At session end:
+        journal.end_session(cycles=50, total_cost=0.15)
+
+        # On next startup, get context for LLM:
+        context = journal.get_context_summary()
+    """
+
+    def __init__(self, path: Optional[Path] = None):
+        self.path = path or DEFAULT_JOURNAL_PATH
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._session_id: Optional[str] = None
+        self._session_actions: List[Dict] = []
+        self._session_insights: List[str] = []
+        self._session_goals: List[str] = []
+        self._session_start: Optional[float] = None
+
+    def start_session(self, agent_name: str, ticker: str, agent_type: str = "general") -> str:
+        """Mark the start of a new agent session. Returns session_id."""
+        self._session_id = f"{ticker}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        self._session_actions = []
+        self._session_insights = []
+        self._session_goals = []
+        self._session_start = time.time()
+
+        self._append({
+            "type": "session_start",
+            "session_id": self._session_id,
+            "agent_name": agent_name,
+            "ticker": ticker,
+            "agent_type": agent_type,
+            "timestamp": datetime.now().isoformat(),
+        })
+        return self._session_id
+
+    def record_action(self, tool: str, params: Dict, status: str, message: str = ""):
+        """Record an action outcome during the current session."""
+        entry = {
+            "type": "action",
+            "session_id": self._session_id,
+            "tool": tool,
+            "status": status,
+            "message": message[:200],
+            "timestamp": datetime.now().isoformat(),
+        }
+        self._append(entry)
+        self._session_actions.append(entry)
+
+    def record_insight(self, insight: str):
+        """Record a lesson learned or insight during this session."""
+        self._append({
+            "type": "insight",
+            "session_id": self._session_id,
+            "insight": insight[:500],
+            "timestamp": datetime.now().isoformat(),
+        })
+        self._session_insights.append(insight[:500])
+
+    def record_goal(self, goal: str, priority: str = "medium"):
+        """Record a goal or intention for current/future sessions."""
+        self._append({
+            "type": "goal",
+            "session_id": self._session_id,
+            "goal": goal[:500],
+            "priority": priority,
+            "timestamp": datetime.now().isoformat(),
+        })
+        self._session_goals.append(goal[:500])
+
+    def end_session(self, cycles: int = 0, total_cost: float = 0.0,
+                    balance_remaining: float = 0.0):
+        """Mark the end of the current session with a summary."""
+        duration = time.time() - self._session_start if self._session_start else 0
+
+        successes = sum(1 for a in self._session_actions if a["status"] == "success")
+        failures = sum(1 for a in self._session_actions if a["status"] != "success")
+
+        # Identify most-used tools
+        tool_counts: Dict[str, int] = {}
+        for a in self._session_actions:
+            tool = a["tool"]
+            tool_counts[tool] = tool_counts.get(tool, 0) + 1
+        top_tools = sorted(tool_counts.items(), key=lambda x: -x[1])[:5]
+
+        self._append({
+            "type": "session_end",
+            "session_id": self._session_id,
+            "cycles": cycles,
+            "total_cost_usd": round(total_cost, 6),
+            "balance_remaining": round(balance_remaining, 4),
+            "duration_seconds": round(duration, 1),
+            "actions_total": len(self._session_actions),
+            "actions_succeeded": successes,
+            "actions_failed": failures,
+            "top_tools": top_tools,
+            "insights": self._session_insights[:10],
+            "goals": self._session_goals[:10],
+            "timestamp": datetime.now().isoformat(),
+        })
+
+        self._session_id = None
+        self._session_actions = []
+        self._session_insights = []
+        self._session_goals = []
+        self._session_start = None
+
+    def get_context_summary(self, max_sessions: int = MAX_CONTEXT_SESSIONS,
+                            max_chars: int = MAX_CONTEXT_CHARS) -> str:
+        """Generate a context summary from recent journal entries for the LLM prompt.
+
+        Returns a concise text block summarizing:
+        - Recent session outcomes
+        - Key insights learned
+        - Outstanding goals
+        """
+        entries = self._load_entries()
+        if not entries:
+            return ""
+
+        # Collect session summaries (from session_end entries)
+        sessions = [e for e in entries if e.get("type") == "session_end"]
+        recent_sessions = sessions[-max_sessions:]
+
+        # Collect all insights and goals
+        all_insights = [e["insight"] for e in entries if e.get("type") == "insight"]
+        all_goals = [e["goal"] for e in entries if e.get("type") == "goal"]
+
+        # Deduplicate insights (keep last occurrence)
+        seen_insights = set()
+        unique_insights = []
+        for insight in reversed(all_insights):
+            normalized = insight.strip().lower()
+            if normalized not in seen_insights:
+                seen_insights.add(normalized)
+                unique_insights.append(insight)
+        unique_insights = list(reversed(unique_insights[-10:]))
+
+        # Build context
+        parts = []
+        parts.append("=== AGENT JOURNAL (Past Sessions) ===")
+
+        if recent_sessions:
+            parts.append(f"\nRecent Sessions ({len(recent_sessions)} of {len(sessions)} total):")
+            for s in recent_sessions:
+                sid = s.get("session_id", "unknown")
+                ts = s.get("timestamp", "")[:10]
+                cycles = s.get("cycles", 0)
+                cost = s.get("total_cost_usd", 0)
+                ok = s.get("actions_succeeded", 0)
+                fail = s.get("actions_failed", 0)
+                tools = ", ".join(t[0] for t in s.get("top_tools", [])[:3])
+                parts.append(f"  [{ts}] {sid}: {cycles} cycles, ${cost:.4f} cost, "
+                             f"{ok} ok/{fail} fail. Tools: {tools}")
+
+                # Include session-level insights/goals
+                for insight in s.get("insights", [])[:2]:
+                    parts.append(f"    Insight: {insight}")
+                for goal in s.get("goals", [])[:2]:
+                    parts.append(f"    Goal: {goal}")
+
+        if unique_insights:
+            parts.append(f"\nKey Insights ({len(unique_insights)}):")
+            for insight in unique_insights[-5:]:
+                parts.append(f"  - {insight}")
+
+        if all_goals:
+            parts.append(f"\nOutstanding Goals ({len(all_goals)}):")
+            for goal in all_goals[-5:]:
+                parts.append(f"  - {goal}")
+
+        context = "\n".join(parts)
+
+        # Truncate if too long
+        if len(context) > max_chars:
+            context = context[:max_chars - 20] + "\n... (truncated)"
+
+        return context
+
+    def get_session_count(self) -> int:
+        """Return the total number of completed sessions."""
+        entries = self._load_entries()
+        return sum(1 for e in entries if e.get("type") == "session_end")
+
+    def get_recent_goals(self, n: int = 5) -> List[str]:
+        """Return the most recent n goals."""
+        entries = self._load_entries()
+        goals = [e["goal"] for e in entries if e.get("type") == "goal"]
+        return goals[-n:]
+
+    def get_recent_insights(self, n: int = 5) -> List[str]:
+        """Return the most recent n insights."""
+        entries = self._load_entries()
+        insights = [e["insight"] for e in entries if e.get("type") == "insight"]
+        return insights[-n:]
+
+    def clear(self):
+        """Clear all journal entries. Use with caution."""
+        if self.path.exists():
+            self.path.unlink()
+
+    def _append(self, entry: Dict):
+        """Append a single JSON entry to the journal file."""
+        with open(self.path, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def _load_entries(self) -> List[Dict]:
+        """Load all journal entries from the JSONL file."""
+        if not self.path.exists():
+            return []
+        entries = []
+        with open(self.path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        return entries

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,175 @@
+"""Tests for AgentJournal - persistent cross-session memory."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from singularity.journal import AgentJournal
+
+
+@pytest.fixture
+def journal(tmp_path):
+    """Create a journal with a temp file."""
+    return AgentJournal(path=tmp_path / "test_journal.jsonl")
+
+
+def test_start_session(journal):
+    sid = journal.start_session("TestAgent", "TEST", "coder")
+    assert sid.startswith("TEST-")
+    assert journal._session_id == sid
+
+
+def test_record_action(journal):
+    journal.start_session("TestAgent", "TEST")
+    journal.record_action("github:create_repo", {"name": "test"}, "success", "Created")
+    assert len(journal._session_actions) == 1
+    assert journal._session_actions[0]["status"] == "success"
+
+
+def test_record_insight(journal):
+    journal.start_session("TestAgent", "TEST")
+    journal.record_insight("Shell commands are fastest for file ops")
+    assert len(journal._session_insights) == 1
+
+
+def test_record_goal(journal):
+    journal.start_session("TestAgent", "TEST")
+    journal.record_goal("Build a REST API", priority="high")
+    assert len(journal._session_goals) == 1
+
+
+def test_end_session(journal):
+    journal.start_session("TestAgent", "TEST")
+    journal.record_action("fs:write", {}, "success", "wrote file")
+    journal.record_action("shell:bash", {}, "error", "command failed")
+    journal.record_insight("Always check exit codes")
+    journal.record_goal("Add error handling")
+    journal.end_session(cycles=10, total_cost=0.05, balance_remaining=9.95)
+
+    entries = journal._load_entries()
+    end_entry = [e for e in entries if e["type"] == "session_end"][0]
+    assert end_entry["cycles"] == 10
+    assert end_entry["total_cost_usd"] == 0.05
+    assert end_entry["actions_succeeded"] == 1
+    assert end_entry["actions_failed"] == 1
+    assert len(end_entry["insights"]) == 1
+    assert len(end_entry["goals"]) == 1
+
+
+def test_session_count(journal):
+    assert journal.get_session_count() == 0
+    journal.start_session("A", "A")
+    journal.end_session(cycles=1)
+    assert journal.get_session_count() == 1
+    journal.start_session("B", "B")
+    journal.end_session(cycles=2)
+    assert journal.get_session_count() == 2
+
+
+def test_get_context_summary_empty(journal):
+    ctx = journal.get_context_summary()
+    assert ctx == ""
+
+
+def test_get_context_summary_with_data(journal):
+    journal.start_session("Agent", "AGT")
+    journal.record_action("fs:write", {}, "success", "ok")
+    journal.record_insight("Writing files works well")
+    journal.record_goal("Build more features")
+    journal.end_session(cycles=5, total_cost=0.01)
+
+    ctx = journal.get_context_summary()
+    assert "AGENT JOURNAL" in ctx
+    assert "AGT-" in ctx
+    assert "Writing files works well" in ctx
+    assert "Build more features" in ctx
+
+
+def test_get_recent_goals(journal):
+    journal.start_session("A", "A")
+    journal.record_goal("Goal 1")
+    journal.record_goal("Goal 2")
+    journal.record_goal("Goal 3")
+    goals = journal.get_recent_goals(2)
+    assert len(goals) == 2
+    assert goals == ["Goal 2", "Goal 3"]
+
+
+def test_get_recent_insights(journal):
+    journal.start_session("A", "A")
+    journal.record_insight("Insight 1")
+    journal.record_insight("Insight 2")
+    insights = journal.get_recent_insights(1)
+    assert len(insights) == 1
+    assert insights == ["Insight 2"]
+
+
+def test_clear(journal):
+    journal.start_session("A", "A")
+    journal.record_action("test", {}, "success")
+    journal.clear()
+    assert journal._load_entries() == []
+
+
+def test_context_truncation(journal):
+    journal.start_session("A", "A")
+    for i in range(100):
+        journal.record_insight(f"Insight number {i} " * 10)
+    journal.end_session()
+    ctx = journal.get_context_summary(max_chars=500)
+    assert len(ctx) <= 500
+
+
+def test_multiple_sessions_context(journal):
+    for i in range(3):
+        journal.start_session(f"Agent{i}", f"A{i}")
+        journal.record_action(f"tool{i}", {}, "success")
+        journal.record_insight(f"Session {i} insight")
+        journal.end_session(cycles=i + 1, total_cost=0.01 * (i + 1))
+
+    ctx = journal.get_context_summary()
+    assert "3 of 3 total" in ctx
+    assert "Session 0 insight" in ctx
+    assert "Session 2 insight" in ctx
+
+
+def test_jsonl_persistence(journal):
+    journal.start_session("A", "A")
+    journal.record_action("test", {}, "success", "ok")
+    journal.end_session()
+
+    # Create a new journal pointing to same file
+    journal2 = AgentJournal(path=journal.path)
+    assert journal2.get_session_count() == 1
+    ctx = journal2.get_context_summary()
+    assert "AGENT JOURNAL" in ctx
+
+
+def test_duplicate_insights_deduplicated(journal):
+    journal.start_session("A", "A")
+    journal.record_insight("Same insight")
+    journal.record_insight("Same insight")
+    journal.record_insight("Different insight")
+    journal.end_session()
+
+    ctx = journal.get_context_summary()
+    # Count occurrences in the Key Insights section
+    insights_section = ctx.split("Key Insights")[1] if "Key Insights" in ctx else ""
+    assert insights_section.count("Same insight") == 1
+
+
+def test_top_tools_tracking(journal):
+    journal.start_session("A", "A")
+    for _ in range(5):
+        journal.record_action("fs:write", {}, "success")
+    for _ in range(3):
+        journal.record_action("shell:bash", {}, "success")
+    journal.record_action("github:push", {}, "success")
+    journal.end_session()
+
+    entries = journal._load_entries()
+    end = [e for e in entries if e["type"] == "session_end"][0]
+    assert end["top_tools"][0] == ["fs:write", 5]
+    assert end["top_tools"][1] == ["shell:bash", 3]


### PR DESCRIPTION
## What This Does

Adds **AgentJournal**, a persistent cross-session memory system that gives the agent awareness of its past. This is the critical missing piece for session continuity — without it, every agent run starts with a blank slate.

## Pillars Served

- **Self-Improvement**: Agent learns from past session outcomes (success rates, errors, insights)
- **Goal Setting**: Agent tracks goals across sessions and sees them in its prompt context

## How It Works

### Journal Module (`singularity/journal.py`)
- **Append-only JSONL storage** — one JSON object per line, crash-safe
- Records: session starts, action outcomes, insights, goals, session-end summaries
- Generates concise context summaries from recent sessions
- Deduplicates insights, tracks top tools, computes success/failure rates

### Agent Integration (`autonomous_agent.py`)
The journal is wired directly into the core run loop with **4 integration points**:

1. **On startup**: `journal.start_session()` + `journal.get_context_summary()` loads past session data
2. **Before thinking**: Past session context injected into `AgentState.project_context` → goes into LLM prompt
3. **After each action**: `journal.record_action()` persists the tool, status, and outcome
4. **On shutdown**: `journal.end_session()` writes a complete session summary

### What the LLM Sees

When the agent starts its 2nd+ session, the LLM prompt includes something like:
```
=== AGENT JOURNAL (Past Sessions) ===

Recent Sessions (3 of 3 total):
  [2025-01-15] AGT-20250115-143022: 50 cycles, $0.1500 cost, 45 ok/5 fail. Tools: fs:write, shell:bash, github:push
    Insight: Shell commands are fastest for bulk file operations
    Goal: Build REST API for code review service
  ...

Key Insights (3):
  - Shell commands are fastest for bulk file operations
  - Always check exit codes before continuing
  - Code analysis sells best as a service

Outstanding Goals (2):
  - Build REST API for code review service
  - Add payment integration
```

## Design Decisions

- **JSONL over JSON**: Append-only writes mean no data loss if the agent crashes mid-session
- **Context budget**: Default 2000 chars, 5 sessions — enough context without bloating the prompt
- **Insight deduplication**: Repeated insights are merged to keep context fresh
- **Zero external deps**: Only uses stdlib `json`, `time`, `datetime`, `pathlib`

## Changes

| File | Change |
|------|--------|
| `singularity/journal.py` | New — AgentJournal class with full lifecycle management |
| `singularity/autonomous_agent.py` | Wire journal into run loop (4 integration points) |
| `tests/test_journal.py` | 16 tests covering all journal operations |

## Tests

All 16 tests pass:
- Session lifecycle (start, record, end)
- Action/insight/goal recording
- Context summary generation
- Multi-session persistence
- Insight deduplication
- Truncation safety
- Top tools tracking
- JSONL file persistence across journal instances