### PR TITLE
Add RetryExecutor for smart execution with retry, circuit breaking, and health tracking

### DIFF
--- a/singularity/retry_executor.py
+++ b/singularity/retry_executor.py
@@ -1,0 +1,272 @@
+"""
+RetryExecutor — Smart execution with retry, circuit breaking, and error tracking.
+
+Enhances the agent's _execute method to:
+1. Retry transient failures with exponential backoff
+2. Track per-skill error rates and success rates  
+3. Circuit-break skills that fail consistently
+4. Provide rich error context for LLM awareness
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+
+
+# Errors that are worth retrying (transient)
+TRANSIENT_PATTERNS = [
+    "timeout", "timed out", "rate limit", "429", "503", "502", "504",
+    "connection", "network", "temporary", "retry", "overloaded",
+    "server error", "service unavailable", "too many requests",
+]
+
+
+@dataclass
+class SkillHealth:
+    """Tracks health metrics for a single skill."""
+    skill_id: str
+    total_calls: int = 0
+    successes: int = 0
+    failures: int = 0
+    consecutive_failures: int = 0
+    last_error: str = ""
+    last_error_time: float = 0.0
+    circuit_open_until: float = 0.0  # timestamp when circuit breaker expires
+
+    @property
+    def success_rate(self) -> float:
+        if self.total_calls == 0:
+            return 1.0
+        return self.successes / self.total_calls
+
+    @property
+    def is_circuit_open(self) -> bool:
+        if self.circuit_open_until <= 0:
+            return False
+        return time.time() < self.circuit_open_until
+
+    def record_success(self):
+        self.total_calls += 1
+        self.successes += 1
+        self.consecutive_failures = 0
+        # Reset circuit breaker on success
+        self.circuit_open_until = 0.0
+
+    def record_failure(self, error: str):
+        self.total_calls += 1
+        self.failures += 1
+        self.consecutive_failures += 1
+        self.last_error = error[:200]
+        self.last_error_time = time.time()
+
+    def open_circuit(self, duration_seconds: float = 60.0):
+        """Open the circuit breaker for the given duration."""
+        self.circuit_open_until = time.time() + duration_seconds
+
+
+class RetryExecutor:
+    """
+    Wraps skill execution with retry logic, circuit breaking, and health tracking.
+    
+    Usage:
+        executor = RetryExecutor(skills_registry)
+        result = await executor.execute(action)
+        summary = executor.get_health_summary()
+    """
+
+    def __init__(
+        self,
+        skills,
+        max_retries: int = 2,
+        base_delay: float = 1.0,
+        max_delay: float = 10.0,
+        circuit_break_threshold: int = 5,
+        circuit_break_duration: float = 60.0,
+    ):
+        """
+        Args:
+            skills: SkillRegistry instance
+            max_retries: Max retry attempts for transient errors
+            base_delay: Base delay in seconds for exponential backoff
+            max_delay: Maximum delay between retries
+            circuit_break_threshold: Consecutive failures before circuit opens
+            circuit_break_duration: Seconds to keep circuit open
+        """
+        self.skills = skills
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.circuit_break_threshold = circuit_break_threshold
+        self.circuit_break_duration = circuit_break_duration
+        self._health: Dict[str, SkillHealth] = {}
+
+    def _get_health(self, skill_id: str) -> SkillHealth:
+        if skill_id not in self._health:
+            self._health[skill_id] = SkillHealth(skill_id=skill_id)
+        return self._health[skill_id]
+
+    def _is_transient(self, error_msg: str) -> bool:
+        """Check if an error is likely transient and worth retrying."""
+        lower = error_msg.lower()
+        return any(pattern in lower for pattern in TRANSIENT_PATTERNS)
+
+    async def execute(self, tool: str, params: Dict) -> Dict:
+        """
+        Execute a tool action with retry logic and circuit breaking.
+        
+        Args:
+            tool: Tool identifier in "skill:action" format
+            params: Action parameters
+            
+        Returns:
+            Result dict with status, data, message, and metadata
+        """
+        if tool == "wait":
+            return {"status": "waited"}
+
+        if ":" not in tool:
+            return {"status": "error", "message": f"Unknown tool: {tool}"}
+
+        parts = tool.split(":", 1)
+        skill_id = parts[0]
+        action_name = parts[1] if len(parts) > 1 else ""
+
+        skill = self.skills.get(skill_id)
+        if not skill:
+            return {"status": "error", "message": f"Skill not found: {skill_id}"}
+
+        health = self._get_health(skill_id)
+
+        # Check circuit breaker
+        if health.is_circuit_open:
+            return {
+                "status": "error",
+                "message": f"Skill '{skill_id}' is temporarily disabled due to repeated failures. "
+                           f"Last error: {health.last_error}. "
+                           f"Will retry in {health.circuit_open_until - time.time():.0f}s.",
+                "_retry_info": {
+                    "circuit_open": True,
+                    "consecutive_failures": health.consecutive_failures,
+                }
+            }
+
+        # Execute with retry
+        last_error = ""
+        attempts = 0
+
+        for attempt in range(self.max_retries + 1):
+            attempts = attempt + 1
+            try:
+                result = await skill.execute(action_name, params)
+                
+                if result.success:
+                    health.record_success()
+                    return {
+                        "status": "success",
+                        "data": result.data,
+                        "message": result.message,
+                        "_retry_info": {"attempts": attempts} if attempts > 1 else {},
+                    }
+                else:
+                    # Skill returned failure (not an exception)
+                    error_msg = result.message or "Action failed"
+                    
+                    if attempt < self.max_retries and self._is_transient(error_msg):
+                        delay = min(self.base_delay * (2 ** attempt), self.max_delay)
+                        await asyncio.sleep(delay)
+                        last_error = error_msg
+                        continue
+                    
+                    health.record_failure(error_msg)
+                    self._check_circuit_break(health)
+                    
+                    return {
+                        "status": "failed",
+                        "data": result.data,
+                        "message": error_msg,
+                        "_retry_info": {
+                            "attempts": attempts,
+                            "skill_success_rate": f"{health.success_rate:.0%}",
+                        }
+                    }
+
+            except Exception as e:
+                error_msg = str(e)
+                
+                if attempt < self.max_retries and self._is_transient(error_msg):
+                    delay = min(self.base_delay * (2 ** attempt), self.max_delay)
+                    await asyncio.sleep(delay)
+                    last_error = error_msg
+                    continue
+                
+                health.record_failure(error_msg)
+                self._check_circuit_break(health)
+                
+                return {
+                    "status": "error",
+                    "message": error_msg,
+                    "_retry_info": {
+                        "attempts": attempts,
+                        "retried": attempts > 1,
+                        "last_transient_error": last_error if last_error != error_msg else "",
+                        "skill_success_rate": f"{health.success_rate:.0%}",
+                    }
+                }
+
+        # Should not reach here, but just in case
+        health.record_failure(last_error)
+        self._check_circuit_break(health)
+        return {
+            "status": "error",
+            "message": f"Failed after {attempts} attempts. Last error: {last_error}",
+        }
+
+    def _check_circuit_break(self, health: SkillHealth):
+        """Open circuit breaker if threshold is exceeded."""
+        if health.consecutive_failures >= self.circuit_break_threshold:
+            health.open_circuit(self.circuit_break_duration)
+
+    def get_health_summary(self) -> str:
+        """Get a summary of skill health for LLM context."""
+        if not self._health:
+            return ""
+
+        lines = []
+        unhealthy = []
+        
+        for sid, h in sorted(self._health.items()):
+            if h.total_calls == 0:
+                continue
+            if h.is_circuit_open:
+                unhealthy.append(f"⚠ {sid}: DISABLED (circuit open, {h.consecutive_failures} consecutive failures)")
+            elif h.success_rate < 0.5 and h.total_calls >= 3:
+                unhealthy.append(f"⚠ {sid}: LOW SUCCESS RATE ({h.success_rate:.0%} over {h.total_calls} calls)")
+
+        if unhealthy:
+            lines.append("Skill Health Warnings:")
+            lines.extend(unhealthy)
+
+        return "\n".join(lines)
+
+    def get_all_health(self) -> Dict[str, Dict]:
+        """Get detailed health metrics for all tracked skills."""
+        result = {}
+        for sid, h in self._health.items():
+            result[sid] = {
+                "total_calls": h.total_calls,
+                "successes": h.successes,
+                "failures": h.failures,
+                "success_rate": h.success_rate,
+                "consecutive_failures": h.consecutive_failures,
+                "last_error": h.last_error,
+                "circuit_open": h.is_circuit_open,
+            }
+        return result
+
+    def reset_health(self, skill_id: Optional[str] = None):
+        """Reset health tracking for a skill or all skills."""
+        if skill_id:
+            self._health.pop(skill_id, None)
+        else:
+            self._health.clear()

--- a/tests/test_retry_executor.py
+++ b/tests/test_retry_executor.py
@@ -1,0 +1,183 @@
+"""Tests for RetryExecutor."""
+import asyncio
+import pytest
+import time
+from unittest.mock import AsyncMock, MagicMock
+from dataclasses import dataclass
+from singularity.retry_executor import RetryExecutor, SkillHealth, TRANSIENT_PATTERNS
+
+
+@dataclass
+class FakeResult:
+    success: bool
+    data: dict = None
+    message: str = ""
+    def __post_init__(self):
+        self.data = self.data or {}
+
+
+class FakeSkill:
+    def __init__(self, results=None):
+        self._results = results or []
+        self._call_count = 0
+
+    async def execute(self, action, params):
+        idx = min(self._call_count, len(self._results) - 1)
+        self._call_count += 1
+        r = self._results[idx]
+        if isinstance(r, Exception):
+            raise r
+        return r
+
+
+class FakeRegistry:
+    def __init__(self, skills=None):
+        self._skills = skills or {}
+    def get(self, skill_id):
+        return self._skills.get(skill_id)
+
+
+@pytest.fixture
+def registry():
+    return FakeRegistry()
+
+
+def test_wait_action(registry):
+    executor = RetryExecutor(registry)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("wait", {}))
+    assert result["status"] == "waited"
+
+
+def test_unknown_tool_format(registry):
+    executor = RetryExecutor(registry)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("badtool", {}))
+    assert result["status"] == "error"
+
+
+def test_skill_not_found(registry):
+    executor = RetryExecutor(registry)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("missing:action", {}))
+    assert result["status"] == "error"
+    assert "not found" in result["message"]
+
+
+def test_successful_execution():
+    skill = FakeSkill([FakeResult(success=True, data={"key": "val"}, message="ok")])
+    reg = FakeRegistry({"myskill": skill})
+    executor = RetryExecutor(reg)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("myskill:do", {}))
+    assert result["status"] == "success"
+    assert result["data"]["key"] == "val"
+
+
+def test_non_transient_failure_no_retry():
+    skill = FakeSkill([FakeResult(success=False, message="invalid parameter")])
+    reg = FakeRegistry({"s": skill})
+    executor = RetryExecutor(reg, max_retries=2, base_delay=0.01)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("s:act", {}))
+    assert result["status"] == "failed"
+    assert skill._call_count == 1  # No retry for non-transient
+
+
+def test_transient_failure_retries():
+    skill = FakeSkill([
+        FakeResult(success=False, message="rate limit exceeded"),
+        FakeResult(success=True, data={"ok": True}),
+    ])
+    reg = FakeRegistry({"s": skill})
+    executor = RetryExecutor(reg, max_retries=2, base_delay=0.01)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("s:act", {}))
+    assert result["status"] == "success"
+    assert skill._call_count == 2
+
+
+def test_transient_exception_retries():
+    skill = FakeSkill([
+        ConnectionError("timeout connecting"),
+        FakeResult(success=True, data={"recovered": True}),
+    ])
+    reg = FakeRegistry({"s": skill})
+    executor = RetryExecutor(reg, max_retries=2, base_delay=0.01)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("s:act", {}))
+    assert result["status"] == "success"
+    assert skill._call_count == 2
+
+
+def test_non_transient_exception_no_retry():
+    skill = FakeSkill([ValueError("bad value")])
+    reg = FakeRegistry({"s": skill})
+    executor = RetryExecutor(reg, max_retries=2, base_delay=0.01)
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("s:act", {}))
+    assert result["status"] == "error"
+    assert skill._call_count == 1
+
+
+def test_circuit_breaker_opens():
+    skill = FakeSkill([FakeResult(success=False, message="server error 503")] * 10)
+    reg = FakeRegistry({"s": skill})
+    executor = RetryExecutor(reg, max_retries=0, circuit_break_threshold=3, circuit_break_duration=60)
+    # 3 failures to trigger circuit
+    for _ in range(3):
+        asyncio.get_event_loop().run_until_complete(executor.execute("s:act", {}))
+    # Next call should be blocked by circuit
+    result = asyncio.get_event_loop().run_until_complete(executor.execute("s:act", {}))
+    assert result["status"] == "error"
+    assert "disabled" in result["message"]
+
+
+def test_circuit_breaker_resets_on_success():
+    health = SkillHealth(skill_id="test")
+    for _ in range(5):
+        health.record_failure("err")
+    health.open_circuit(60)
+    assert health.is_circuit_open
+    # Simulate success after circuit expires
+    health.circuit_open_until = 0
+    health.record_success()
+    assert health.consecutive_failures == 0
+    assert not health.is_circuit_open
+
+
+def test_health_summary_empty():
+    executor = RetryExecutor(FakeRegistry())
+    assert executor.get_health_summary() == ""
+
+
+def test_health_summary_with_warnings():
+    executor = RetryExecutor(FakeRegistry())
+    h = executor._get_health("badskill")
+    for _ in range(5):
+        h.record_failure("err")
+    h.open_circuit(60)
+    summary = executor.get_health_summary()
+    assert "badskill" in summary
+    assert "DISABLED" in summary
+
+
+def test_get_all_health():
+    executor = RetryExecutor(FakeRegistry())
+    h = executor._get_health("s1")
+    h.record_success()
+    h.record_failure("err")
+    info = executor.get_all_health()
+    assert info["s1"]["total_calls"] == 2
+    assert info["s1"]["successes"] == 1
+
+
+def test_reset_health():
+    executor = RetryExecutor(FakeRegistry())
+    executor._get_health("s1").record_success()
+    executor._get_health("s2").record_success()
+    executor.reset_health("s1")
+    assert "s1" not in executor._health
+    assert "s2" in executor._health
+    executor.reset_health()
+    assert len(executor._health) == 0
+
+
+def test_success_rate():
+    h = SkillHealth(skill_id="test")
+    assert h.success_rate == 1.0
+    h.record_success()
+    h.record_failure("err")
+    assert h.success_rate == 0.5


### PR DESCRIPTION
## What

Adds a `RetryExecutor` module that replaces the basic `_execute()` call in the agent's run loop with smart execution that includes:

1. **Automatic retry with exponential backoff** for transient errors (timeouts, rate limits, 503s, connection errors)
2. **Circuit breaker pattern** — skills that fail consecutively (5+ times) are temporarily disabled to avoid wasting cycles and budget
3. **Per-skill health tracking** — success rates, failure counts, consecutive failures, last error message
4. **Health summary in LLM context** — skill health warnings are injected into `project_context` so the LLM knows which skills are unreliable and can avoid them

## Why (Self-Improvement Pillar)

The agent's current `_execute()` method has no retry logic and provides minimal error context. When a skill fails due to a transient error (network timeout, rate limit), the agent just records the failure and moves on — wasting cycles on actions that would succeed with a simple retry.

With RetryExecutor:
- **Transient errors are retried automatically** (up to 2 retries with exponential backoff)
- **Persistent failures trigger circuit breaking** — the agent stops trying broken skills instead of burning budget
- **The LLM gets health warnings** — it can see "⚠ github: DISABLED (circuit open, 5 consecutive failures)" and choose a different approach
- **Error context is richer** — retry info, success rates, and failure patterns are included in results

## Changes

| File | Change |
|------|--------|
| `singularity/retry_executor.py` | New module: `RetryExecutor` class with `SkillHealth` tracking |
| `singularity/autonomous_agent.py` | Wire `RetryExecutor` into agent init and run loop; inject health summary into `project_context` |
| `tests/test_retry_executor.py` | 15 tests covering retry logic, circuit breaking, health tracking, and edge cases |

## Key Design Decisions

- **Transient error detection** uses pattern matching against common error strings (timeout, rate limit, 503, etc.)
- **Circuit breaker** opens after 5 consecutive failures, stays open for 60 seconds, resets on first success
- **Original `_execute()` method preserved** as fallback — RetryExecutor is additive, not destructive
- **Zero external dependencies** — uses only stdlib asyncio and time
- **Health summary only shown when there are problems** — no noise when everything is healthy

## Tests

```
15 passed in 15.25s
```

Covers: successful execution, transient retry, non-transient no-retry, circuit breaker opening, circuit reset on success, health summary generation, health metrics, edge cases (wait, unknown tool, missing skill).