### PR TITLE
Add SkillAutoWire: configure() method for automatic skill wiring

### DIFF
--- a/singularity/skills/content.py
+++ b/singularity/skills/content.py
@@ -11,7 +11,7 @@ Enables agents to generate content using LLM:
 """
 
 import json
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from .base import Skill, SkillResult, SkillManifest, SkillAction
 
 try:
@@ -176,6 +176,12 @@ class ContentCreationSkill(Skill):
         self.llm = llm
         self.llm_type = llm_type
         self.model = model
+
+    def configure(self, context: Dict[str, Any]) -> None:
+        """Auto-wire LLM from agent's cognition engine."""
+        cognition = context.get("cognition")
+        if cognition:
+            self.set_llm(cognition.llm, cognition.llm_type, cognition.llm_model)
 
     def check_credentials(self) -> bool:
         """Check if LLM is available"""

--- a/tests/test_skill_autowire.py
+++ b/tests/test_skill_autowire.py
@@ -1,0 +1,122 @@
+"""Tests for Skill auto-wiring via configure() method."""
+import pytest
+from singularity.skills.base import Skill, SkillResult, SkillManifest, SkillAction, SkillRegistry
+from typing import Dict, Any
+
+
+class SimpleSkill(Skill):
+    """Test skill that doesn't need wiring."""
+    @property
+    def manifest(self):
+        return SkillManifest(
+            skill_id="simple", name="Simple", version="1.0",
+            category="test", description="A simple test skill",
+            actions=[], required_credentials=[],
+        )
+
+    async def execute(self, action, params):
+        return SkillResult(success=True)
+
+
+class WirableSkill(Skill):
+    """Test skill that uses configure() for auto-wiring."""
+    def __init__(self, credentials=None):
+        super().__init__(credentials)
+        self.agent_name = None
+        self.cognition_ref = None
+        self.configured = False
+
+    @property
+    def manifest(self):
+        return SkillManifest(
+            skill_id="wirable", name="Wirable", version="1.0",
+            category="test", description="A wirable test skill",
+            actions=[], required_credentials=[],
+        )
+
+    def configure(self, context: Dict[str, Any]) -> None:
+        self.agent_name = context.get("agent_name")
+        self.cognition_ref = context.get("cognition")
+        self.configured = True
+
+    async def execute(self, action, params):
+        return SkillResult(success=True)
+
+
+class FailingConfigSkill(Skill):
+    """Skill whose configure() raises an error."""
+    @property
+    def manifest(self):
+        return SkillManifest(
+            skill_id="failing_config", name="FailConfig", version="1.0",
+            category="test", description="Fails during configure",
+            actions=[], required_credentials=[],
+        )
+
+    def configure(self, context):
+        raise ValueError("Configuration failed!")
+
+    async def execute(self, action, params):
+        return SkillResult(success=True)
+
+
+def test_base_skill_configure_is_noop():
+    """Default configure() should do nothing."""
+    skill = SimpleSkill()
+    skill.configure({"agent_name": "test"})  # Should not raise
+
+
+def test_wirable_skill_configure():
+    """Skills can override configure() to receive context."""
+    skill = WirableSkill()
+    assert skill.configured is False
+    skill.configure({"agent_name": "TestAgent", "cognition": "mock_cognition"})
+    assert skill.configured is True
+    assert skill.agent_name == "TestAgent"
+    assert skill.cognition_ref == "mock_cognition"
+
+
+def test_registry_configure_all():
+    """SkillRegistry.configure_all() calls configure() on all skills."""
+    registry = SkillRegistry()
+    registry.install(SimpleSkill)
+    registry.install(WirableSkill)
+
+    context = {"agent_name": "TestBot", "cognition": "mock"}
+    errors = registry.configure_all(context)
+
+    assert errors == {}
+    wirable = registry.get("wirable")
+    assert wirable.configured is True
+    assert wirable.agent_name == "TestBot"
+
+
+def test_registry_configure_all_handles_errors():
+    """configure_all() captures errors without stopping."""
+    registry = SkillRegistry()
+    registry.install(WirableSkill)
+    registry.install(FailingConfigSkill)
+
+    errors = registry.configure_all({"agent_name": "Test"})
+
+    assert "failing_config" in errors
+    assert "Configuration failed!" in errors["failing_config"]
+    # Other skills still configured
+    wirable = registry.get("wirable")
+    assert wirable.configured is True
+
+
+def test_configure_with_empty_context():
+    """configure() handles empty context gracefully."""
+    skill = WirableSkill()
+    skill.configure({})
+    assert skill.configured is True
+    assert skill.agent_name is None
+    assert skill.cognition_ref is None
+
+
+def test_configure_all_returns_empty_on_no_skills():
+    """configure_all() on empty registry returns empty dict."""
+    registry = SkillRegistry()
+    errors = registry.configure_all({"agent_name": "Test"})
+    assert errors == {}


### PR DESCRIPTION
## Pillar: Self-Improvement 🔄

### What this adds
Introduces a `configure(context)` pattern that lets skills automatically wire themselves to agent capabilities, replacing the manual if-chain in `_init_skills`.

### Changes
1. **`Skill.configure(context)`** - New base class method (no-op default). Skills that need agent integration override this to extract what they need from the context dict.
2. **`SkillRegistry.configure_all(context)`** - Batch-configures all installed skills. Isolates errors: if one skill's `configure()` fails, others still get configured.
3. **`ContentCreationSkill.configure()`** - Proof-of-concept override that auto-wires the LLM from the agent's cognition engine.
4. **6 focused tests** covering all configure patterns.

### Why this matters
Currently `_init_skills` in `autonomous_agent.py` has a growing if-chain:
```python
if skill_class == ContentCreationSkill and skill:
    skill.set_llm(...)
if skill_class == SelfModifySkill and skill:
    skill.set_cognition_hooks(...)
if skill_class == SteeringSkill and skill:
    skill.set_model_hooks(...)
# ...and growing
```

With SkillAutoWire, this becomes:
```python
# After installing all skills:
context = {"cognition": self.cognition, "agent": self}
self.skills.configure_all(context)
```

Each skill knows what it needs. No more modifying `autonomous_agent.py` every time a new skill needs wiring.

### Next steps
- Add `configure()` overrides to SelfModifySkill, SteeringSkill, MemorySkill, OrchestratorSkill
- Refactor `_init_skills` to call `self.skills.configure_all(context)` after installation
- Future skills can self-wire without touching the agent code