### PR TITLE
Add SkillHealthMonitor for failure-aware agent prompts

### DIFF
--- a/singularity/skill_health.py
+++ b/singularity/skill_health.py
@@ -1,0 +1,150 @@
+"""
+SkillHealthMonitor — Tracks per-skill success/failure rates and generates
+warnings for the agent when skills are consistently failing.
+
+Wired into the agent run loop to inject failure-awareness context into
+the LLM prompt, enabling the agent to avoid broken tools and adapt.
+
+Self-Improvement pillar: act → measure → adapt feedback loop.
+"""
+
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+
+class SkillHealthMonitor:
+    """
+    Monitors skill execution health from recent_actions history.
+
+    Tracks:
+    - Per-skill success/failure counts
+    - Consecutive failure streaks
+    - Recently failed tools (to warn the agent)
+
+    Generates a context string for injection into the LLM prompt.
+    """
+
+    def __init__(self, failure_threshold: int = 3, lookback: int = 20):
+        """
+        Args:
+            failure_threshold: Number of consecutive failures before warning.
+            lookback: How many recent actions to analyze.
+        """
+        self.failure_threshold = failure_threshold
+        self.lookback = lookback
+
+    def analyze(self, recent_actions: List[Dict]) -> Dict:
+        """
+        Analyze recent actions and return health metrics.
+
+        Returns dict with:
+            - skill_stats: {tool: {success: int, failure: int, rate: float}}
+            - failing_skills: list of tools with consecutive failures >= threshold
+            - last_errors: {tool: last_error_message}
+            - consecutive_failures: current streak of any failures
+        """
+        actions = recent_actions[-self.lookback:]
+        if not actions:
+            return {
+                "skill_stats": {},
+                "failing_skills": [],
+                "last_errors": {},
+                "consecutive_failures": 0,
+            }
+
+        # Per-skill stats
+        stats = defaultdict(lambda: {"success": 0, "failure": 0})
+        last_errors = {}
+        consecutive_by_skill = defaultdict(int)
+
+        for action in actions:
+            tool = action.get("tool", "unknown")
+            status = action.get("result", {}).get("status", "unknown")
+
+            if status == "success":
+                stats[tool]["success"] += 1
+                consecutive_by_skill[tool] = 0
+            elif status in ("error", "failed"):
+                stats[tool]["failure"] += 1
+                consecutive_by_skill[tool] += 1
+                error_msg = action.get("result", {}).get("message", "unknown error")
+                last_errors[tool] = error_msg
+
+        # Calculate success rates
+        skill_stats = {}
+        for tool, counts in stats.items():
+            total = counts["success"] + counts["failure"]
+            rate = counts["success"] / total if total > 0 else 0.0
+            skill_stats[tool] = {
+                "success": counts["success"],
+                "failure": counts["failure"],
+                "rate": round(rate, 2),
+            }
+
+        # Find skills exceeding failure threshold
+        failing_skills = [
+            tool for tool, count in consecutive_by_skill.items()
+            if count >= self.failure_threshold
+        ]
+
+        # Overall consecutive failure streak (any tool)
+        consecutive_failures = 0
+        for action in reversed(actions):
+            status = action.get("result", {}).get("status", "unknown")
+            if status in ("error", "failed"):
+                consecutive_failures += 1
+            else:
+                break
+
+        return {
+            "skill_stats": skill_stats,
+            "failing_skills": failing_skills,
+            "last_errors": last_errors,
+            "consecutive_failures": consecutive_failures,
+        }
+
+    def generate_context(self, recent_actions: List[Dict]) -> str:
+        """
+        Generate a context string for injection into the LLM prompt.
+
+        Returns empty string if everything is healthy.
+        Returns warnings when failures are detected.
+        """
+        health = self.analyze(recent_actions)
+
+        parts = []
+
+        # Warn about consistently failing skills
+        if health["failing_skills"]:
+            failing_list = ", ".join(health["failing_skills"])
+            parts.append(
+                f"⚠️ FAILING TOOLS: {failing_list} — these have failed "
+                f"{self.failure_threshold}+ times in a row. "
+                "Try a different approach or tool."
+            )
+            for tool in health["failing_skills"]:
+                if tool in health["last_errors"]:
+                    parts.append(f"  Last error from {tool}: {health['last_errors'][tool][:200]}")
+
+        # Warn about overall failure streak
+        if health["consecutive_failures"] >= 2:
+            parts.append(
+                f"⚠️ {health['consecutive_failures']} consecutive failures. "
+                "Stop and reconsider your approach before trying again."
+            )
+
+        # Show skill health summary if there are any failures
+        skills_with_failures = {
+            tool: s for tool, s in health["skill_stats"].items()
+            if s["failure"] > 0
+        }
+        if skills_with_failures:
+            summary_lines = []
+            for tool, s in sorted(skills_with_failures.items(), key=lambda x: x[1]["rate"]):
+                summary_lines.append(
+                    f"  {tool}: {s['rate']*100:.0f}% success ({s['success']}/{s['success']+s['failure']})"
+                )
+            if summary_lines:
+                parts.append("Tool health:\n" + "\n".join(summary_lines))
+
+        return "\n".join(parts)

--- a/tests/test_skill_health.py
+++ b/tests/test_skill_health.py
@@ -1,0 +1,135 @@
+"""Tests for SkillHealthMonitor."""
+
+from singularity.skill_health import SkillHealthMonitor
+
+
+def _action(tool, status, message=""):
+    return {"tool": tool, "result": {"status": status, "message": message}}
+
+
+def test_empty_actions():
+    m = SkillHealthMonitor()
+    h = m.analyze([])
+    assert h["skill_stats"] == {}
+    assert h["failing_skills"] == []
+    assert h["consecutive_failures"] == 0
+
+
+def test_all_success():
+    m = SkillHealthMonitor()
+    actions = [_action("fs:read", "success") for _ in range(5)]
+    h = m.analyze(actions)
+    assert h["skill_stats"]["fs:read"]["rate"] == 1.0
+    assert h["failing_skills"] == []
+    assert h["consecutive_failures"] == 0
+
+
+def test_mixed_results():
+    m = SkillHealthMonitor()
+    actions = [
+        _action("fs:read", "success"),
+        _action("fs:read", "error", "file not found"),
+        _action("fs:read", "success"),
+    ]
+    h = m.analyze(actions)
+    assert h["skill_stats"]["fs:read"]["success"] == 2
+    assert h["skill_stats"]["fs:read"]["failure"] == 1
+    assert h["skill_stats"]["fs:read"]["rate"] == 0.67
+
+
+def test_consecutive_failures_detected():
+    m = SkillHealthMonitor(failure_threshold=3)
+    actions = [
+        _action("shell:bash", "error", "timeout"),
+        _action("shell:bash", "error", "timeout"),
+        _action("shell:bash", "error", "timeout"),
+    ]
+    h = m.analyze(actions)
+    assert "shell:bash" in h["failing_skills"]
+    assert h["consecutive_failures"] == 3
+
+
+def test_consecutive_failures_reset_on_success():
+    m = SkillHealthMonitor(failure_threshold=3)
+    actions = [
+        _action("shell:bash", "error", "timeout"),
+        _action("shell:bash", "error", "timeout"),
+        _action("shell:bash", "success"),
+        _action("shell:bash", "error", "timeout"),
+    ]
+    h = m.analyze(actions)
+    assert "shell:bash" not in h["failing_skills"]
+
+
+def test_overall_consecutive_failures():
+    m = SkillHealthMonitor()
+    actions = [
+        _action("fs:read", "success"),
+        _action("shell:bash", "error", "err1"),
+        _action("fs:write", "failed", "err2"),
+    ]
+    h = m.analyze(actions)
+    assert h["consecutive_failures"] == 2
+
+
+def test_generate_context_healthy():
+    m = SkillHealthMonitor()
+    actions = [_action("fs:read", "success") for _ in range(5)]
+    ctx = m.generate_context(actions)
+    assert ctx == ""
+
+
+def test_generate_context_warnings():
+    m = SkillHealthMonitor(failure_threshold=2)
+    actions = [
+        _action("shell:bash", "error", "command not found"),
+        _action("shell:bash", "error", "command not found"),
+    ]
+    ctx = m.generate_context(actions)
+    assert "FAILING TOOLS" in ctx
+    assert "shell:bash" in ctx
+    assert "command not found" in ctx
+
+
+def test_generate_context_streak_warning():
+    m = SkillHealthMonitor(failure_threshold=10)
+    actions = [
+        _action("a:x", "error", "e1"),
+        _action("b:y", "failed", "e2"),
+        _action("c:z", "error", "e3"),
+    ]
+    ctx = m.generate_context(actions)
+    assert "3 consecutive failures" in ctx
+    assert "reconsider" in ctx
+
+
+def test_lookback_limit():
+    m = SkillHealthMonitor(lookback=3)
+    actions = [_action("fs:read", "error", "old")] * 10 + [_action("fs:read", "success")] * 3
+    h = m.analyze(actions)
+    assert h["skill_stats"]["fs:read"]["rate"] == 1.0
+
+
+def test_last_errors_tracked():
+    m = SkillHealthMonitor()
+    actions = [
+        _action("fs:read", "error", "first error"),
+        _action("fs:read", "error", "second error"),
+    ]
+    h = m.analyze(actions)
+    assert h["last_errors"]["fs:read"] == "second error"
+
+
+def test_multiple_skills():
+    m = SkillHealthMonitor(failure_threshold=2)
+    actions = [
+        _action("fs:read", "success"),
+        _action("shell:bash", "error", "e1"),
+        _action("shell:bash", "error", "e2"),
+        _action("fs:write", "success"),
+    ]
+    h = m.analyze(actions)
+    assert "shell:bash" in h["failing_skills"]
+    assert "fs:read" not in h["failing_skills"]
+    assert h["skill_stats"]["fs:read"]["rate"] == 1.0
+    assert h["skill_stats"]["shell:bash"]["rate"] == 0.0


### PR DESCRIPTION
## Summary

Adds a **SkillHealthMonitor** that makes the agent aware of tool failures, enabling it to adapt its behavior when skills are consistently broken.

## Pillar: Self-Improvement 🔄

This closes the **act → measure → adapt** feedback loop in the core agent. Before this change, the agent had no awareness of skill failure patterns — it would repeatedly call broken tools, wasting money and cycles. Now it gets explicit warnings in its prompt.

## What's New

### `singularity/skill_health.py` — SkillHealthMonitor
- **Per-skill tracking**: Counts successes and failures for each tool from `recent_actions`
- **Consecutive failure detection**: Identifies skills that have failed N+ times in a row
- **Overall streak detection**: Warns when multiple actions in a row are failing
- **Context generation**: Produces warning strings for LLM prompt injection
  - `⚠️ FAILING TOOLS: shell:bash — failed 3+ times in a row. Try a different approach.`
  - `⚠️ 5 consecutive failures. Stop and reconsider your approach.`
  - Tool health summary with success percentages

### Agent Integration (`autonomous_agent.py`)
- `SkillHealthMonitor` instantiated on agent `__init__`
- Before each `cognition.think()`, health context is generated from `recent_actions`
- Injected into `AgentState.project_context` → appears in the LLM prompt
- When everything is healthy, context is empty (no noise)

### Tests
- **12 tests** covering: empty actions, all-success, mixed results, consecutive failures, streak detection, lookback limits, multi-skill scenarios, context generation

## Why This Matters

Without failure awareness, an agent with $10 balance can burn through it all retrying a broken command. With this change:
1. The agent **sees** which tools are failing and their error messages
2. It gets explicit **instructions** to try a different approach
3. It can make **informed decisions** about which tools to use

This is the first module wired directly into the core agent run loop that provides runtime self-awareness about execution health.