### PR TITLE
Add AdaptiveIntelligence for in-session learning and loop detection

### DIFF
--- a/singularity/adaptive.py
+++ b/singularity/adaptive.py
@@ -1,0 +1,162 @@
+"""
+Adaptive Intelligence — in-session learning for the agent.
+
+Tracks tool success/failure rates, detects repeated failures (loops),
+and generates context summaries injected into the LLM prompt so the
+agent can make smarter decisions over time.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class ToolStats:
+    """Tracks success/failure counts for a single tool."""
+    successes: int = 0
+    failures: int = 0
+    consecutive_failures: int = 0
+    last_error: str = ""
+
+    @property
+    def total(self) -> int:
+        return self.successes + self.failures
+
+    @property
+    def success_rate(self) -> float:
+        if self.total == 0:
+            return 1.0
+        return self.successes / self.total
+
+
+class AdaptiveIntelligence:
+    """
+    In-session adaptive learning engine.
+
+    Wired into the agent run loop to:
+    1. Record outcomes of every action (record_outcome)
+    2. Detect repeated failures / loops (is_looping)
+    3. Generate a context summary for the LLM (get_context)
+    """
+
+    def __init__(self, loop_threshold: int = 3, history_window: int = 6):
+        self.tool_stats: Dict[str, ToolStats] = defaultdict(ToolStats)
+        self.recent_tools: List[str] = []
+        self.loop_threshold = loop_threshold
+        self.history_window = history_window
+        self.warnings: List[str] = []
+
+    def record_outcome(self, tool: str, params: Dict, success: bool,
+                       error_message: str = "") -> None:
+        """Record the outcome of an action."""
+        stats = self.tool_stats[tool]
+        if success:
+            stats.successes += 1
+            stats.consecutive_failures = 0
+        else:
+            stats.failures += 1
+            stats.consecutive_failures += 1
+            stats.last_error = error_message[:200]
+
+        self.recent_tools.append(tool)
+        # Keep bounded
+        if len(self.recent_tools) > 50:
+            self.recent_tools = self.recent_tools[-50:]
+
+        # Generate warnings for repeated failures
+        if stats.consecutive_failures >= self.loop_threshold:
+            warning = (f"WARNING: '{tool}' has failed {stats.consecutive_failures} "
+                       f"times in a row. Last error: {stats.last_error}. "
+                       f"Try a different approach.")
+            if warning not in self.warnings:
+                self.warnings = self.warnings[-4:]  # Keep last 5
+                self.warnings.append(warning)
+
+    def is_looping(self) -> bool:
+        """Detect if the agent is stuck in a loop of repeated actions."""
+        if len(self.recent_tools) < self.history_window:
+            return False
+
+        recent = self.recent_tools[-self.history_window:]
+
+        # Check if all recent actions are the same tool
+        if len(set(recent)) == 1:
+            return True
+
+        # Check for repeating pattern of length 2 or 3
+        for pattern_len in (2, 3):
+            if self.history_window >= pattern_len * 2:
+                pattern = recent[-pattern_len:]
+                preceding = recent[-(pattern_len * 2):-pattern_len]
+                if pattern == preceding:
+                    return True
+
+        return False
+
+    def get_failing_tools(self) -> List[str]:
+        """Return tools with consecutive failure streaks."""
+        return [
+            tool for tool, stats in self.tool_stats.items()
+            if stats.consecutive_failures >= 2
+        ]
+
+    def get_context(self) -> str:
+        """
+        Generate a context summary for the LLM prompt.
+        Returns empty string if there's nothing noteworthy to report.
+        """
+        lines = []
+
+        # Report tools with poor success rates (only if enough data)
+        struggling = []
+        for tool, stats in self.tool_stats.items():
+            if stats.total >= 2 and stats.success_rate < 0.5:
+                struggling.append(
+                    f"  - {tool}: {stats.successes}/{stats.total} succeeded"
+                    f" (last error: {stats.last_error})"
+                )
+
+        if struggling:
+            lines.append("⚠ TOOLS WITH LOW SUCCESS RATE:")
+            lines.extend(struggling)
+
+        # Report active failure streaks
+        streaking = []
+        for tool, stats in self.tool_stats.items():
+            if stats.consecutive_failures >= 2:
+                streaking.append(
+                    f"  - {tool}: {stats.consecutive_failures} consecutive failures"
+                )
+
+        if streaking:
+            lines.append("🔴 ACTIVE FAILURE STREAKS (try a different approach!):")
+            lines.extend(streaking)
+
+        # Loop detection warning
+        if self.is_looping():
+            lines.append(
+                "🔄 LOOP DETECTED: You are repeating the same actions. "
+                "STOP and try a completely different strategy."
+            )
+
+        # Include recent warnings
+        if self.warnings:
+            lines.append("📋 RECENT WARNINGS:")
+            for w in self.warnings[-3:]:
+                lines.append(f"  - {w}")
+
+        # Report overall stats summary (only after several cycles)
+        total_actions = sum(s.total for s in self.tool_stats.values())
+        total_successes = sum(s.successes for s in self.tool_stats.values())
+        if total_actions >= 5:
+            rate = total_successes / total_actions * 100
+            lines.append(
+                f"📊 Session stats: {total_successes}/{total_actions} actions "
+                f"succeeded ({rate:.0f}%) across {len(self.tool_stats)} tools"
+            )
+
+        if not lines:
+            return ""
+
+        return "\n--- ADAPTIVE INTELLIGENCE ---\n" + "\n".join(lines) + "\n"

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,0 +1,106 @@
+"""Tests for AdaptiveIntelligence module."""
+
+from singularity.adaptive import AdaptiveIntelligence, ToolStats
+
+
+def test_tool_stats_defaults():
+    s = ToolStats()
+    assert s.total == 0
+    assert s.success_rate == 1.0
+
+
+def test_record_success():
+    ai = AdaptiveIntelligence()
+    ai.record_outcome("shell:bash", {}, success=True)
+    assert ai.tool_stats["shell:bash"].successes == 1
+    assert ai.tool_stats["shell:bash"].failures == 0
+    assert ai.tool_stats["shell:bash"].consecutive_failures == 0
+
+
+def test_record_failure():
+    ai = AdaptiveIntelligence()
+    ai.record_outcome("shell:bash", {}, success=False, error_message="timeout")
+    assert ai.tool_stats["shell:bash"].failures == 1
+    assert ai.tool_stats["shell:bash"].consecutive_failures == 1
+    assert ai.tool_stats["shell:bash"].last_error == "timeout"
+
+
+def test_consecutive_failures_reset_on_success():
+    ai = AdaptiveIntelligence()
+    ai.record_outcome("x:y", {}, False, "err1")
+    ai.record_outcome("x:y", {}, False, "err2")
+    assert ai.tool_stats["x:y"].consecutive_failures == 2
+    ai.record_outcome("x:y", {}, True)
+    assert ai.tool_stats["x:y"].consecutive_failures == 0
+
+
+def test_loop_detection_same_tool():
+    ai = AdaptiveIntelligence(history_window=4)
+    for _ in range(4):
+        ai.record_outcome("a:b", {}, True)
+    assert ai.is_looping()
+
+
+def test_loop_detection_pattern():
+    ai = AdaptiveIntelligence(history_window=4)
+    for _ in range(2):
+        ai.record_outcome("a:b", {}, True)
+        ai.record_outcome("c:d", {}, True)
+    assert ai.is_looping()
+
+
+def test_no_loop_varied():
+    ai = AdaptiveIntelligence(history_window=4)
+    ai.record_outcome("a:b", {}, True)
+    ai.record_outcome("c:d", {}, True)
+    ai.record_outcome("e:f", {}, True)
+    ai.record_outcome("g:h", {}, True)
+    assert not ai.is_looping()
+
+
+def test_context_empty_initially():
+    ai = AdaptiveIntelligence()
+    assert ai.get_context() == ""
+
+
+def test_context_shows_failing_tools():
+    ai = AdaptiveIntelligence()
+    ai.record_outcome("x:y", {}, False, "broken")
+    ai.record_outcome("x:y", {}, False, "still broken")
+    ctx = ai.get_context()
+    assert "LOW SUCCESS RATE" in ctx or "FAILURE STREAKS" in ctx
+    assert "x:y" in ctx
+
+
+def test_context_shows_loop_warning():
+    ai = AdaptiveIntelligence(history_window=4)
+    for _ in range(4):
+        ai.record_outcome("a:b", {}, False, "err")
+    ctx = ai.get_context()
+    assert "LOOP DETECTED" in ctx
+
+
+def test_context_session_stats():
+    ai = AdaptiveIntelligence()
+    for i in range(5):
+        ai.record_outcome(f"t{i}:a", {}, True)
+    ctx = ai.get_context()
+    assert "5/5" in ctx
+    assert "100%" in ctx
+
+
+def test_warnings_generated_at_threshold():
+    ai = AdaptiveIntelligence(loop_threshold=3)
+    for i in range(3):
+        ai.record_outcome("bad:tool", {}, False, "fail")
+    assert len(ai.warnings) > 0
+    assert "bad:tool" in ai.warnings[0]
+
+
+def test_failing_tools_list():
+    ai = AdaptiveIntelligence()
+    ai.record_outcome("a:b", {}, False)
+    ai.record_outcome("a:b", {}, False)
+    ai.record_outcome("c:d", {}, True)
+    assert "a:b" in ai.get_failing_tools()
+    assert "c:d" not in ai.get_failing_tools()


### PR DESCRIPTION
## Pillar: Self-Improvement 🧠

### What this adds

**AdaptiveIntelligence** — an in-session learning engine that makes the agent smarter over the course of a run by tracking what works and what doesn't, then feeding that intelligence back into the LLM context.

### The Problem

The agent currently treats every cycle independently. When an action fails, the failure appears in `recent_actions` but:
- There's no aggregate tracking of which tools work well vs. poorly
- The agent can repeat the same failing action indefinitely
- There's no loop detection to break repetitive behavior
- The `project_context` field in AgentState is never populated

### The Solution

**`singularity/adaptive.py`** — New module with:

- **`ToolStats`** — Per-tool success/failure tracking with consecutive failure streaks
- **`AdaptiveIntelligence`** — Session-scoped learning engine with:
  - `record_outcome()` — Records success/failure of every action
  - `is_looping()` — Detects repeated action patterns (same tool repeated, or alternating patterns)
  - `get_failing_tools()` — Returns tools with active failure streaks
  - `get_context()` — Generates a context summary for LLM injection

**Context injected into LLM prompt includes:**
- ⚠ Tools with low success rates (< 50%)
- 🔴 Active consecutive failure streaks
- 🔄 Loop detection warnings
- 📋 Recent warnings about problematic tools
- 📊 Overall session success statistics

### Wiring into Agent

Three surgical changes to `autonomous_agent.py`:
1. **Import + init** — `self.adaptive = AdaptiveIntelligence()` created at agent init
2. **Context injection** — `adaptive_context` passed as `project_context` to `AgentState`
3. **Outcome recording** — After each `_execute()`, records success/failure to adaptive engine

### How it works in practice

```
Cycle 1: agent tries shell:bash → succeeds → recorded
Cycle 2: agent tries github:create_repo → fails (no token) → recorded
Cycle 3: agent tries github:create_repo again → 2nd failure → streak warning generated
Cycle 4: LLM sees "🔴 github:create_repo: 2 consecutive failures" in prompt → tries different approach
Cycle 5+: If agent keeps repeating → "🔄 LOOP DETECTED" warning injected
```

### Tests

13 tests covering:
- ToolStats defaults and calculations
- Success/failure recording and streak tracking
- Loop detection (same tool, alternating patterns, varied actions)
- Context generation (empty, failures, loops, session stats)
- Warning generation at threshold
- Failing tools list

### Why this matters

This is the first modification to the core agent that creates a **genuine feedback loop within a single session**. The agent now has self-awareness about its own performance and can adapt its behavior accordingly. This closes the act → measure → adapt loop that's fundamental to autonomous intelligence.