### PR TITLE
Add automatic skill discovery to replace hardcoded imports

### DIFF
--- a/singularity/autonomous_agent.py
+++ b/singularity/autonomous_agent.py
@@ -28,22 +28,14 @@ ACTIVITY_FILE = Path(__file__).parent / "data" / "activity.json"
 
 from .cognition import CognitionEngine, AgentState, Decision, Action, TokenUsage
 from .skills.base import SkillRegistry
+from .skill_discovery import discover_skills
+
+# Import specific skills only for wiring hooks (type checking)
 from .skills.content import ContentCreationSkill
-from .skills.twitter import TwitterSkill
-from .skills.github import GitHubSkill
-from .skills.namecheap import NamecheapSkill
-from .skills.email import EmailSkill
-from .skills.browser import BrowserSkill
-from .skills.vercel import VercelSkill
-from .skills.filesystem import FilesystemSkill
-from .skills.shell import ShellSkill
-from .skills.mcp_client import MCPClientSkill
-from .skills.request import RequestSkill
 from .skills.self_modify import SelfModifySkill
 from .skills.steering import SteeringSkill
 from .skills.memory import MemorySkill
 from .skills.orchestrator import OrchestratorSkill
-from .skills.crypto import CryptoSkill
 
 
 class AutonomousAgent:
@@ -178,24 +170,8 @@ class AutonomousAgent:
         }
         self.skills.set_credentials(credentials)
 
-        skill_classes = [
-            ContentCreationSkill,
-            TwitterSkill,
-            GitHubSkill,
-            NamecheapSkill,
-            EmailSkill,
-            BrowserSkill,
-            VercelSkill,
-            FilesystemSkill,
-            ShellSkill,
-            MCPClientSkill,
-            RequestSkill,
-            SelfModifySkill,
-            SteeringSkill,
-            MemorySkill,
-            OrchestratorSkill,
-            CryptoSkill,
-        ]
+        # Auto-discover all Skill subclasses instead of hardcoding
+        skill_classes = discover_skills()
 
         for skill_class in skill_classes:
             try:

--- a/singularity/skill_discovery.py
+++ b/singularity/skill_discovery.py
@@ -1,0 +1,123 @@
+"""
+Automatic Skill Discovery
+
+Scans the skills package to find all Skill subclasses without requiring
+hardcoded imports. This replaces the manual import list in autonomous_agent.py.
+
+Usage:
+    from singularity.skill_discovery import discover_skills
+    skill_classes = discover_skills()
+    # Returns list of Skill subclasses found in singularity/skills/
+"""
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Type
+
+from .skills.base import Skill
+
+
+def discover_skills(
+    package_path: Optional[str] = None,
+    exclude: Optional[Set[str]] = None,
+    include_only: Optional[Set[str]] = None,
+) -> List[Type[Skill]]:
+    """
+    Discover all Skill subclasses in the skills package.
+
+    Scans all .py files in the skills directory, imports them, and finds
+    classes that inherit from Skill.
+
+    Args:
+        package_path: Path to skills package directory. Defaults to
+                      singularity/skills/.
+        exclude: Set of skill class names to exclude (e.g. {"BrowserSkill"}).
+        include_only: If set, only include these skill class names.
+
+    Returns:
+        List of Skill subclass types, deduplicated and sorted by name.
+    """
+    if package_path is None:
+        package_path = str(Path(__file__).parent / "skills")
+
+    exclude = exclude or set()
+    discovered: Dict[str, Type[Skill]] = {}
+
+    skills_package = importlib.import_module("singularity.skills")
+    package_dir = Path(package_path)
+
+    for module_info in pkgutil.iter_modules([str(package_dir)]):
+        module_name = module_info.name
+
+        # Skip base, __init__, and private modules
+        if module_name.startswith("_") or module_name == "base":
+            continue
+
+        try:
+            module = importlib.import_module(f"singularity.skills.{module_name}")
+        except Exception:
+            continue
+
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            # Must be a Skill subclass but not Skill itself
+            if not issubclass(obj, Skill) or obj is Skill:
+                continue
+
+            # Must be defined in this module (not re-imported)
+            if obj.__module__ != module.__name__:
+                continue
+
+            # Apply filters
+            if name in exclude:
+                continue
+            if include_only is not None and name not in include_only:
+                continue
+
+            discovered[name] = obj
+
+    # Sort by class name for deterministic ordering
+    return [discovered[name] for name in sorted(discovered)]
+
+
+def discover_skills_with_metadata(
+    package_path: Optional[str] = None,
+    exclude: Optional[Set[str]] = None,
+) -> List[Dict]:
+    """
+    Discover skills and return metadata about each.
+
+    Returns:
+        List of dicts with 'class', 'name', 'module', 'skill_id',
+        'required_credentials' for each discovered skill.
+    """
+    skills = discover_skills(package_path=package_path, exclude=exclude)
+    result = []
+
+    for skill_class in skills:
+        info = {
+            "class": skill_class,
+            "class_name": skill_class.__name__,
+            "module": skill_class.__module__,
+        }
+
+        # Try to get manifest info without credentials
+        try:
+            instance = skill_class(credentials={})
+            manifest = instance.manifest
+            info["skill_id"] = manifest.skill_id
+            info["skill_name"] = manifest.name
+            info["category"] = manifest.category
+            info["required_credentials"] = manifest.required_credentials
+            info["action_count"] = len(manifest.actions)
+        except Exception:
+            info["skill_id"] = None
+            info["skill_name"] = skill_class.__name__
+            info["category"] = "unknown"
+            info["required_credentials"] = []
+            info["action_count"] = 0
+
+        result.append(info)
+
+    return result

--- a/tests/test_skill_discovery.py
+++ b/tests/test_skill_discovery.py
@@ -1,0 +1,81 @@
+"""Tests for automatic skill discovery."""
+
+import pytest
+from singularity.skill_discovery import discover_skills, discover_skills_with_metadata
+from singularity.skills.base import Skill
+
+
+def test_discover_skills_returns_list():
+    """discover_skills returns a list of Skill subclasses."""
+    skills = discover_skills()
+    assert isinstance(skills, list)
+    assert len(skills) > 0
+
+
+def test_all_discovered_are_skill_subclasses():
+    """Every discovered class is a subclass of Skill."""
+    for cls in discover_skills():
+        assert issubclass(cls, Skill)
+        assert cls is not Skill
+
+
+def test_discovers_known_skills():
+    """Known built-in skills are discovered."""
+    names = {cls.__name__ for cls in discover_skills()}
+    expected = {
+        "FilesystemSkill", "ShellSkill", "GitHubSkill",
+        "ContentCreationSkill", "SelfModifySkill",
+    }
+    assert expected.issubset(names), f"Missing: {expected - names}"
+
+
+def test_exclude_filter():
+    """Skills in exclude set are not returned."""
+    all_skills = discover_skills()
+    filtered = discover_skills(exclude={"FilesystemSkill", "ShellSkill"})
+    names = {cls.__name__ for cls in filtered}
+    assert "FilesystemSkill" not in names
+    assert "ShellSkill" not in names
+    assert len(filtered) < len(all_skills)
+
+
+def test_include_only_filter():
+    """Only skills in include_only set are returned."""
+    filtered = discover_skills(include_only={"FilesystemSkill", "ShellSkill"})
+    names = {cls.__name__ for cls in filtered}
+    assert names == {"FilesystemSkill", "ShellSkill"}
+
+
+def test_deterministic_order():
+    """Results are in sorted order by class name."""
+    skills = discover_skills()
+    names = [cls.__name__ for cls in skills]
+    assert names == sorted(names)
+
+
+def test_discover_with_metadata():
+    """discover_skills_with_metadata returns dicts with expected keys."""
+    meta = discover_skills_with_metadata()
+    assert len(meta) > 0
+    for item in meta:
+        assert "class" in item
+        assert "class_name" in item
+        assert "module" in item
+        assert "skill_id" in item
+        assert "required_credentials" in item
+        assert "action_count" in item
+
+
+def test_metadata_has_valid_skill_ids():
+    """Metadata includes valid skill_id strings."""
+    meta = discover_skills_with_metadata()
+    for item in meta:
+        # skill_id should be set for well-formed skills
+        assert item["skill_id"] is not None or item["class_name"]
+
+
+def test_no_base_class_in_results():
+    """The Skill base class itself is never in results."""
+    skills = discover_skills()
+    for cls in skills:
+        assert cls.__name__ != "Skill"


### PR DESCRIPTION
## Summary

Replaces the hardcoded skill import list in `autonomous_agent.py` with automatic discovery. New skills are now found automatically — just drop a `.py` file in `singularity/skills/` and it's loaded.

## Pillar: Self-Improvement 🧠

This is the #1 integration issue noted across multiple sessions: the agent's `_init_skills()` method required manually importing and listing every skill class. This PR eliminates that friction.

## What Changed

### New: `singularity/skill_discovery.py`
- **`discover_skills()`** — Scans `singularity/skills/` using `pkgutil.iter_modules` + `importlib`, finds all `Skill` subclasses, returns them sorted deterministically
- **`discover_skills_with_metadata()`** — Same discovery but returns rich metadata (skill_id, category, required_credentials, action_count)
- **Filtering** — `exclude` and `include_only` parameters for selective skill loading
- **Error isolation** — Import failures for individual skills are caught and skipped (won't crash the agent)
- **No external dependencies** — Uses only stdlib `importlib`, `inspect`, `pkgutil`

### Modified: `singularity/autonomous_agent.py`
- Removed 11 hardcoded skill imports (kept 5 for wiring hooks: ContentCreation, SelfModify, Steering, Memory, Orchestrator)
- Replaced `skill_classes = [ContentCreationSkill, TwitterSkill, ...]` with `skill_classes = discover_skills()`
- All special wiring hooks (LLM injection, cognition hooks, etc.) preserved as-is

### New: `tests/test_skill_discovery.py`
9 tests covering:
- Discovery returns non-empty list of Skill subclasses
- Known built-in skills are found (FilesystemSkill, ShellSkill, etc.)
- `exclude` filter removes specified skills
- `include_only` filter returns only specified skills
- Results are in deterministic sorted order
- Metadata includes expected fields
- Base `Skill` class is never in results

## Why This Matters

| Before | After |
|--------|-------|
| Add a new skill → edit 3 files (skill.py, `__init__.py`, autonomous_agent.py) | Add a new skill → create 1 file |
| 16 hardcoded imports at top of agent | 5 imports (only for wiring hooks) |
| Import error in one skill → agent fails to start | Import errors are isolated |
| Config-driven skill loading impossible | `discover_skills(include_only={"ShellSkill"})` works |

## Tests

```
tests/test_skill_discovery.py - 9 passed ✅
```