### PR TITLE
Add conversation memory to CognitionEngine for multi-turn reasoning

### DIFF
--- a/tests/test_conversation_memory.py
+++ b/tests/test_conversation_memory.py
@@ -1,0 +1,92 @@
+"""Tests for CognitionEngine conversation memory."""
+import pytest
+from singularity.cognition import CognitionEngine, AgentState
+
+
+@pytest.fixture
+def engine():
+    return CognitionEngine(llm_provider="none", agent_name="Test", agent_ticker="TST")
+
+
+def test_initial_conversation_empty(engine):
+    assert engine.get_conversation_length() == 0
+    assert engine.get_conversation_turns() == 0
+
+
+def test_clear_conversation(engine):
+    engine._conversation_history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    cleared = engine.clear_conversation()
+    assert cleared == 2
+    assert engine.get_conversation_length() == 0
+
+
+def test_set_max_history_turns(engine):
+    engine._conversation_history = [
+        {"role": "user", "content": f"msg {i}"} if i % 2 == 0
+        else {"role": "assistant", "content": f"reply {i}"}
+        for i in range(20)
+    ]
+    assert engine.get_conversation_length() == 20
+    engine.set_max_history_turns(3)
+    assert engine._max_history_turns == 3
+    assert engine.get_conversation_length() == 6  # 3 turns * 2 messages
+
+
+def test_set_max_history_turns_minimum(engine):
+    engine.set_max_history_turns(0)
+    assert engine._max_history_turns == 1
+
+
+def test_get_conversation_summary_empty(engine):
+    summary = engine.get_conversation_summary()
+    assert summary["turns"] == 0
+    assert summary["last_user"] is None
+    assert summary["last_assistant"] is None
+
+
+def test_get_conversation_summary_with_data(engine):
+    engine._conversation_history = [
+        {"role": "user", "content": "what should I do?"},
+        {"role": "assistant", "content": '{"tool": "wait", "params": {}}'},
+    ]
+    summary = engine.get_conversation_summary()
+    assert summary["turns"] == 1
+    assert summary["max_turns"] == 10
+    assert "what should" in summary["last_user"]
+    assert "wait" in summary["last_assistant"]
+
+
+def test_max_history_turns_constructor():
+    engine = CognitionEngine(llm_provider="none", max_history_turns=5)
+    assert engine._max_history_turns == 5
+
+
+def test_conversation_history_included_in_messages():
+    """Verify that think() would build messages including history."""
+    engine = CognitionEngine(llm_provider="none", agent_name="Test", agent_ticker="TST")
+    # Simulate prior conversation
+    engine._conversation_history = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous answer"},
+    ]
+    # The think method builds messages = list(self._conversation_history) + new user msg
+    # Since provider is "none", think() returns wait. But we can verify history is there.
+    assert len(engine._conversation_history) == 2
+    messages = list(engine._conversation_history)
+    messages.append({"role": "user", "content": "new question"})
+    assert len(messages) == 3
+    assert messages[0]["role"] == "user"
+    assert messages[2]["content"] == "new question"
+
+
+@pytest.mark.asyncio
+async def test_think_returns_wait_with_no_backend():
+    engine = CognitionEngine(llm_provider="none", agent_name="Test", agent_ticker="TST")
+    state = AgentState(balance=10.0, burn_rate=0.01, runway_hours=100.0)
+    decision = await engine.think(state)
+    assert decision.action.tool == "wait"
+    # History should NOT be updated when no backend (returns early)
+    assert engine.get_conversation_length() == 0


### PR DESCRIPTION
## Summary

Adds persistent conversation memory to `CognitionEngine.think()`, transforming the agent from a stateless single-shot decision maker into a multi-turn reasoning agent.

## Pillar: Self-Improvement 🧠

This is a fundamental upgrade to agent intelligence. Previously, every `think()` call was a completely fresh conversation — the LLM had zero memory of its prior reasoning. Now the agent maintains a sliding window of conversation history, enabling:

- **Coherent multi-step planning**: The agent remembers what it decided to do and why
- **Learning from results**: It can see how its previous reasoning led to success or failure
- **Building on context**: Complex tasks that span multiple cycles can be reasoned about coherently
- **Reduced redundancy**: The LLM doesn't need to re-derive context from scratch each cycle

## Changes

### `singularity/cognition.py`
- Added `_conversation_history` list that persists user/assistant messages across `think()` calls
- Added `max_history_turns` constructor parameter (default: 10 turn pairs)
- Automatic sliding window trimming — oldest turns are dropped when limit is exceeded
- All 6 LLM backends updated to include conversation history:
  - **Anthropic**: Native multi-turn `messages` array
  - **OpenAI**: Native multi-turn `messages` array  
  - **Vertex Claude**: Native multi-turn `messages` array
  - **Vertex Gemini**: Conversation text prepended to prompt
  - **vLLM**: Conversation text formatted into prompt
  - **Transformers**: Full messages array via `apply_chat_template`
- Increased `max_tokens` from 500 → 1024 for richer agent responses
- New methods:
  - `clear_conversation()` — reset history, returns count cleared
  - `get_conversation_length()` — number of messages
  - `get_conversation_turns()` — number of user/assistant pairs
  - `set_max_history_turns(n)` — adjust window size at runtime
  - `get_conversation_summary()` — dict with turns, max, last messages

### `tests/test_conversation_memory.py`
- 9 focused tests covering initialization, clearing, trimming, summary, constructor params, and think() fallback behavior

## Why This Matters

Without conversation memory, the agent is like a person with amnesia — it can see a brief summary of what happened but has no recollection of *why* it made those choices. With this change, the agent can:

```
Cycle 1: "I need to create a web app. Let me start with the file structure."
Cycle 2: "In my last turn I created the file structure. Now let me write the main app code."
Cycle 3: "The app code is written. I previously planned to add tests, so let me do that."
```

Instead of:
```
Cycle 1: "I need to create a web app. Let me start with the file structure."
Cycle 2: "I see a file was created. I should figure out what to do next..."
Cycle 3: "There are some files. Let me look around and decide what's needed..."
```