### PR TITLE
Fix nested JSON parsing and make LLM params configurable

### DIFF
--- a/tests/test_cognition_improvements.py
+++ b/tests/test_cognition_improvements.py
@@ -1,0 +1,76 @@
+"""Tests for cognition improvements: nested JSON parsing and configurable params."""
+import pytest
+from singularity.cognition import CognitionEngine, Action
+
+
+@pytest.fixture
+def engine():
+    return CognitionEngine(llm_provider="none")
+
+
+class TestParseActionNestedJSON:
+    """Test _parse_action handles nested JSON in params."""
+
+    def test_flat_json(self, engine):
+        resp = '{"tool": "wait", "params": {}, "reasoning": "idle"}'
+        action = engine._parse_action(resp)
+        assert action.tool == "wait"
+
+    def test_nested_params(self, engine):
+        resp = '{"tool": "fs:write", "params": {"path": "a.py", "content": "x = {1: 2}"}, "reasoning": "write"}'
+        action = engine._parse_action(resp)
+        assert action.tool == "fs:write"
+        assert action.params["path"] == "a.py"
+        assert "x = {1: 2}" in action.params["content"]
+
+    def test_deeply_nested(self, engine):
+        resp = '{"tool": "shell:bash", "params": {"command": "echo \'{\\"a\\": 1}\'"}, "reasoning": "test"}'
+        action = engine._parse_action(resp)
+        assert action.tool == "shell:bash"
+        assert "command" in action.params
+
+    def test_json_in_prose(self, engine):
+        resp = 'I will write the file.\n{"tool": "fs:write", "params": {"path": "x.py", "data": {"nested": true}}, "reasoning": "ok"}\nDone.'
+        action = engine._parse_action(resp)
+        assert action.tool == "fs:write"
+        assert action.params["data"]["nested"] is True
+
+    def test_multiple_json_picks_tool(self, engine):
+        resp = 'Config: {"key": "val"}\nAction: {"tool": "wait", "params": {}, "reasoning": "none"}'
+        action = engine._parse_action(resp)
+        assert action.tool == "wait"
+
+    def test_fallback_tool_pattern(self, engine):
+        resp = "I should use shell:bash to run it"
+        action = engine._parse_action(resp)
+        assert action.tool == "shell:bash"
+
+    def test_no_json_returns_wait(self, engine):
+        action = engine._parse_action("no valid json here")
+        assert action.tool == "wait"
+
+    def test_list_in_params(self, engine):
+        resp = '{"tool": "fs:write", "params": {"files": ["a.py", "b.py"]}, "reasoning": "multi"}'
+        action = engine._parse_action(resp)
+        assert action.tool == "fs:write"
+        assert action.params["files"] == ["a.py", "b.py"]
+
+
+class TestConfigurableParams:
+    """Test that max_tokens and temperature are configurable."""
+
+    def test_default_max_tokens(self):
+        engine = CognitionEngine(llm_provider="none")
+        assert engine.max_tokens == 1024
+
+    def test_custom_max_tokens(self):
+        engine = CognitionEngine(llm_provider="none", max_tokens=2048)
+        assert engine.max_tokens == 2048
+
+    def test_default_temperature(self):
+        engine = CognitionEngine(llm_provider="none")
+        assert engine.temperature == 0.2
+
+    def test_custom_temperature(self):
+        engine = CognitionEngine(llm_provider="none", temperature=0.7)
+        assert engine.temperature == 0.7


### PR DESCRIPTION
## Pillar: Self-Improvement (Core Engine)

### Problem
Three critical issues in `cognition.py` were limiting agent capability:

1. **`_parse_action` can't handle nested JSON** — The regex `r'\{[^{}]*"tool"[^{}]*\}'` literally cannot match any JSON containing nested braces. This means tool calls like `{"tool": "fs:write", "params": {"path": "a.py", "content": "hello"}}` silently **drop the entire params dict**, since the inner `{}` breaks the regex. This is a fundamental bug affecting every tool with structured parameters.

2. **`max_tokens=500` hardcoded in 6 places** — Severely limits agent response length. 500 tokens is barely enough for reasoning + JSON output. Changed to configurable with default of 1024.

3. **`temperature` inconsistently applied** — Set to 0.2 for some providers, missing for others (OpenAI had no temperature setting at all). Now configurable and consistently applied across all providers.

### Changes

**`singularity/cognition.py`:**
- Added `max_tokens` (default 1024) and `temperature` (default 0.2) to `CognitionEngine.__init__`
- Replaced all 6 hardcoded `max_tokens=500` with `self.max_tokens`
- Applied `self.temperature` consistently across all LLM provider branches
- Added `_extract_json_with_tool()` — robust brace-matching JSON parser for nested structures
- `_parse_action` now tries brace-matching first, falls back to simple regex, then tool name pattern

**`tests/test_cognition_improvements.py`:**
- 12 focused tests covering nested JSON parsing (8 tests) and parameter configurability (4 tests)
- Tests nested dicts, lists, JSON in prose, multiple JSON objects, fallback patterns

### Impact
- **Every tool call with complex params** now works correctly (was silently broken before)
- **Agent responses are more complete** with 1024 tokens vs 500
- **Consistent LLM behavior** across all providers with explicit temperature control
- Zero breaking changes — new defaults are backward-compatible