### PR TITLE
Add rich action result feedback for LLM context

### DIFF
--- a/singularity/cognition.py
+++ b/singularity/cognition.py
@@ -578,13 +578,23 @@ class CognitionEngine:
             for t in state.tools
         ])
 
-        # Format recent actions
+        # Format recent actions with rich result feedback
         recent_text = ""
         if state.recent_actions:
-            recent_text = "\nRecent actions:\n" + "\n".join([
-                f"- {a['tool']}: {a.get('result', {}).get('status', 'unknown')}"
-                for a in state.recent_actions[-5:]
-            ])
+            try:
+                from .result_feedback import format_recent_actions
+                recent_text = format_recent_actions(
+                    state.recent_actions,
+                    max_actions=5,
+                    max_total_len=2000,
+                    max_per_result=400,
+                )
+            except ImportError:
+                # Fallback to simple format
+                recent_text = "\nRecent actions:\n" + "\n".join([
+                    f"- {a['tool']}: {a.get('result', {}).get('status', 'unknown')}"
+                    for a in state.recent_actions[-5:]
+                ])
 
         user_prompt = f"""Current state:
 - Balance: ${state.balance:.4f}

--- a/singularity/result_feedback.py
+++ b/singularity/result_feedback.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Result Feedback - Rich action result formatting for LLM context.
+
+Currently the agent only sees "tool: status" for previous actions.
+This module formats full action results so the LLM can reason about
+what actually happened - seeing file contents, command outputs,
+error messages, API responses, etc.
+
+This is critical for multi-step reasoning: the agent needs to see
+the result of step 1 to decide what to do in step 2.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+
+def _truncate(text: str, max_len: int = 500) -> str:
+    """Truncate text with ellipsis indicator."""
+    if len(text) <= max_len:
+        return text
+    half = (max_len - 20) // 2
+    return text[:half] + f"\n... [{len(text) - max_len} chars truncated] ...\n" + text[-half:]
+
+
+def _format_data(data: Any, max_len: int = 500) -> str:
+    """Format result data for display, handling various types."""
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return _truncate(data, max_len)
+    if isinstance(data, dict):
+        # For dicts, show key-value pairs, prioritizing important keys
+        priority_keys = ["content", "output", "stdout", "result", "text", "message",
+                         "path", "url", "status", "error", "count", "items"]
+        lines = []
+        seen = set()
+
+        # Show priority keys first
+        for key in priority_keys:
+            if key in data:
+                val = data[key]
+                if isinstance(val, str) and len(val) > 200:
+                    val = _truncate(val, 200)
+                elif isinstance(val, (dict, list)):
+                    val = _truncate(json.dumps(val, default=str), 200)
+                lines.append(f"    {key}: {val}")
+                seen.add(key)
+
+        # Then show remaining keys (truncated)
+        for key, val in data.items():
+            if key in seen:
+                continue
+            if isinstance(val, str) and len(val) > 100:
+                val = _truncate(val, 100)
+            elif isinstance(val, (dict, list)):
+                val = _truncate(json.dumps(val, default=str), 100)
+            lines.append(f"    {key}: {val}")
+
+        result = "\n".join(lines)
+        return _truncate(result, max_len)
+
+    if isinstance(data, list):
+        if len(data) == 0:
+            return "    (empty list)"
+        items = []
+        for i, item in enumerate(data[:5]):
+            items.append(f"    [{i}]: {_truncate(str(item), 100)}")
+        if len(data) > 5:
+            items.append(f"    ... and {len(data) - 5} more items")
+        return "\n".join(items)
+
+    return _truncate(str(data), max_len)
+
+
+def format_action_result(action: Dict, max_result_len: int = 500) -> str:
+    """
+    Format a single action record for LLM context.
+
+    Args:
+        action: Dict with keys: tool, params, result, cycle, api_cost_usd, tokens
+        max_result_len: Max chars for result data
+
+    Returns:
+        Formatted string showing tool, status, and key result data
+    """
+    tool = action.get("tool", "unknown")
+    result = action.get("result", {})
+    status = result.get("status", "unknown")
+    cycle = action.get("cycle", "?")
+
+    # Status indicator
+    icon = "✓" if status == "success" else "✗" if status in ("error", "failed") else "○"
+
+    lines = [f"  {icon} [{cycle}] {tool} → {status}"]
+
+    # Show error/message if present
+    message = result.get("message", "")
+    if message and status in ("error", "failed"):
+        lines.append(f"    error: {_truncate(message, 200)}")
+    elif message and status == "success":
+        lines.append(f"    message: {_truncate(message, 150)}")
+
+    # Show result data for successful actions
+    data = result.get("data")
+    if data is not None:
+        formatted = _format_data(data, max_result_len)
+        if formatted.strip():
+            lines.append(f"    data:\n{formatted}")
+
+    return "\n".join(lines)
+
+
+def format_recent_actions(
+    actions: List[Dict],
+    max_actions: int = 5,
+    max_total_len: int = 2000,
+    max_per_result: int = 400,
+) -> str:
+    """
+    Format recent actions for inclusion in the LLM prompt.
+
+    Shows full results for the most recent actions so the LLM can
+    reason about what happened. Older actions get progressively
+    less detail.
+
+    Args:
+        actions: List of action records (most recent last)
+        max_actions: Max number of actions to show
+        max_total_len: Max total length of formatted output
+        max_per_result: Max chars per individual result
+
+    Returns:
+        Formatted string for prompt inclusion
+    """
+    if not actions:
+        return ""
+
+    recent = actions[-max_actions:]
+    formatted_parts = []
+
+    for i, action in enumerate(recent):
+        # Most recent actions get more detail
+        is_latest = (i == len(recent) - 1)
+        is_recent = (i >= len(recent) - 2)
+
+        if is_latest:
+            result_len = max_per_result
+        elif is_recent:
+            result_len = max_per_result // 2
+        else:
+            result_len = 100
+
+        formatted = format_action_result(action, max_result_len=result_len)
+        formatted_parts.append(formatted)
+
+    result = "\nRecent actions (oldest to newest):\n" + "\n".join(formatted_parts)
+
+    # Final truncation if still too long
+    if len(result) > max_total_len:
+        result = result[:max_total_len - 50] + "\n  ... (earlier actions truncated)"
+
+    return result

--- a/tests/test_result_feedback.py
+++ b/tests/test_result_feedback.py
@@ -1,0 +1,113 @@
+"""Tests for result_feedback module."""
+
+import pytest
+from singularity.result_feedback import (
+    _truncate,
+    _format_data,
+    format_action_result,
+    format_recent_actions,
+)
+
+
+class TestTruncate:
+    def test_short_text(self):
+        assert _truncate("hello", 100) == "hello"
+
+    def test_long_text(self):
+        text = "x" * 1000
+        result = _truncate(text, 100)
+        assert len(result) < 200  # Should be roughly max_len
+        assert "truncated" in result
+
+    def test_exact_length(self):
+        text = "x" * 100
+        assert _truncate(text, 100) == text
+
+
+class TestFormatData:
+    def test_none(self):
+        assert _format_data(None) == ""
+
+    def test_string(self):
+        assert _format_data("hello") == "hello"
+
+    def test_long_string(self):
+        result = _format_data("x" * 1000, max_len=100)
+        assert len(result) < 200
+
+    def test_dict_with_priority_keys(self):
+        data = {"content": "file data", "other": "stuff", "path": "/tmp/f"}
+        result = _format_data(data)
+        assert "content:" in result
+        assert "path:" in result
+
+    def test_empty_list(self):
+        assert "(empty list)" in _format_data([])
+
+    def test_list(self):
+        result = _format_data(["a", "b", "c"])
+        assert "[0]: a" in result
+        assert "[2]: c" in result
+
+    def test_long_list(self):
+        result = _format_data(list(range(20)))
+        assert "15 more items" in result
+
+
+class TestFormatActionResult:
+    def test_success(self):
+        action = {"tool": "fs:read", "result": {"status": "success", "data": {"content": "hello"}}, "cycle": 1}
+        result = format_action_result(action)
+        assert "✓" in result
+        assert "fs:read" in result
+        assert "hello" in result
+
+    def test_error(self):
+        action = {"tool": "shell:bash", "result": {"status": "error", "message": "not found"}, "cycle": 2}
+        result = format_action_result(action)
+        assert "✗" in result
+        assert "not found" in result
+
+    def test_no_data(self):
+        action = {"tool": "wait", "result": {"status": "waited"}, "cycle": 3}
+        result = format_action_result(action)
+        assert "wait" in result
+
+
+class TestFormatRecentActions:
+    def test_empty(self):
+        assert format_recent_actions([]) == ""
+
+    def test_single_action(self):
+        actions = [{"tool": "fs:read", "result": {"status": "success", "data": {"content": "hi"}}, "cycle": 1}]
+        result = format_recent_actions(actions)
+        assert "Recent actions" in result
+        assert "fs:read" in result
+
+    def test_multiple_actions(self):
+        actions = [
+            {"tool": "fs:read", "result": {"status": "success", "data": {"content": "a"}}, "cycle": 1},
+            {"tool": "shell:bash", "result": {"status": "error", "message": "fail"}, "cycle": 2},
+            {"tool": "fs:write", "result": {"status": "success", "data": {"path": "/f"}}, "cycle": 3},
+        ]
+        result = format_recent_actions(actions)
+        assert "fs:read" in result
+        assert "shell:bash" in result
+        assert "fs:write" in result
+
+    def test_max_actions_limit(self):
+        actions = [{"tool": f"t:{i}", "result": {"status": "success"}, "cycle": i} for i in range(20)]
+        result = format_recent_actions(actions, max_actions=3)
+        # Should only show the last 3
+        assert "t:17" in result
+        assert "t:18" in result
+        assert "t:19" in result
+        assert "t:0" not in result
+
+    def test_total_length_limit(self):
+        actions = [
+            {"tool": "fs:read", "result": {"status": "success", "data": {"content": "x" * 5000}}, "cycle": i}
+            for i in range(5)
+        ]
+        result = format_recent_actions(actions, max_total_len=500)
+        assert len(result) <= 600  # Allow some slack for truncation message


### PR DESCRIPTION
## Pillar: Self-Improvement (Core Agent Quality)

### Problem
The agent's LLM only sees `"tool: status"` for its previous actions. It never sees the actual result data — file contents, command outputs, API responses, error messages. This makes multi-step reasoning impossible: the agent can't reason about what happened in step 1 when deciding step 2.

**Before:**
```
Recent actions:
- fs:read: success
- shell:bash: error
```

**After:**
```
Recent actions (oldest to newest):
  ✓ [1] fs:read → success
    data:
    content: hello world
  ✗ [2] shell:bash → error
    error: command not found
```

### What this PR adds

**New module: `singularity/result_feedback.py`**
- `format_recent_actions()` — formats action history with full result data
- `format_action_result()` — formats individual action with status indicators
- Smart truncation: most recent action gets 400 chars, older ones get progressively less
- Priority key ordering: shows `content`, `output`, `path`, `error` before other fields
- Status indicators: ✓ (success), ✗ (error/failed), ○ (other)
- Handles all data types: strings, dicts, lists, nested objects

**Integration: `cognition.py` `think()` method**
- Replaces the 1-line status-only format with rich result feedback
- Graceful fallback to old format if module import fails
- Total output capped at 2000 chars to avoid context overflow

**Tests: 18 tests** covering truncation, data formatting, action rendering, and limits

### Why this matters
This is the single highest-leverage improvement for agent reasoning quality. Without seeing action results, the agent is essentially blind to the outcomes of its own actions. With this change, the agent can:
- Read a file, then reason about its contents
- Run a command, then process the output
- See error messages and adjust its approach
- Chain multiple actions with full context

### Impact
- Zero new dependencies
- Backwards compatible (graceful fallback)
- Applies to all LLM providers (Anthropic, OpenAI, Vertex, vLLM, Transformers)
