### PR TITLE
Add PromptCache for LLM response caching and cost reduction

### DIFF
--- a/singularity/prompt_cache.py
+++ b/singularity/prompt_cache.py
@@ -1,0 +1,373 @@
+"""
+PromptCache - LLM response caching to reduce API costs.
+
+Caches LLM responses by prompt hash to avoid duplicate API calls.
+Supports TTL-based expiration and persistent file-backed storage.
+
+This directly improves agent survival by reducing API spend - the
+agent's primary burn rate.
+
+Pillar: Self-Improvement + Revenue (cost reduction)
+"""
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+
+@dataclass
+class CacheEntry:
+    """A cached LLM response."""
+    prompt_hash: str
+    response_text: str
+    model: str
+    provider: str
+    created_at: float
+    ttl_seconds: float
+    hit_count: int = 0
+    estimated_cost_saved: float = 0.0
+
+    def is_expired(self) -> bool:
+        """Check if this cache entry has expired."""
+        if self.ttl_seconds <= 0:
+            return False  # No expiration
+        return (time.time() - self.created_at) > self.ttl_seconds
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CacheEntry":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class CacheStats:
+    """Cache performance statistics."""
+    total_hits: int = 0
+    total_misses: int = 0
+    total_cost_saved: float = 0.0
+    total_entries: int = 0
+    evictions: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.total_hits + self.total_misses
+        return self.total_hits / total if total > 0 else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "total_hits": self.total_hits,
+            "total_misses": self.total_misses,
+            "total_cost_saved": self.total_cost_saved,
+            "total_entries": self.total_entries,
+            "evictions": self.evictions,
+            "hit_rate": round(self.hit_rate, 4),
+        }
+
+
+class PromptCache:
+    """
+    LLM response cache with file-backed persistence.
+
+    Caches responses keyed by a hash of (system_prompt, user_prompt, model).
+    Saves money by returning cached responses for identical prompts.
+
+    Features:
+    - Exact-match caching via SHA-256 hash
+    - TTL-based expiration (default: 1 hour)
+    - LRU eviction when cache is full
+    - File-backed persistence across agent restarts
+    - Cost savings tracking
+
+    Usage:
+        cache = PromptCache(cache_dir="./cache", max_entries=500)
+        
+        # Check cache before calling LLM
+        cached = cache.get(system_prompt, user_prompt, model)
+        if cached:
+            response_text = cached.response_text  # Free!
+        else:
+            response_text = call_llm(...)  # Costs money
+            cache.put(system_prompt, user_prompt, model, response_text, 
+                     provider="anthropic", estimated_cost=0.003)
+    """
+
+    def __init__(
+        self,
+        cache_dir: str = "./data/prompt_cache",
+        max_entries: int = 1000,
+        default_ttl: float = 3600.0,  # 1 hour default
+        enabled: bool = True,
+    ):
+        self.cache_dir = Path(cache_dir)
+        self.max_entries = max_entries
+        self.default_ttl = default_ttl
+        self.enabled = enabled
+        self._cache: Dict[str, CacheEntry] = {}
+        self._stats = CacheStats()
+        self._loaded = False
+
+    def _ensure_loaded(self):
+        """Lazy-load cache from disk on first access."""
+        if self._loaded:
+            return
+        self._loaded = True
+        self._load_from_disk()
+
+    @staticmethod
+    def _make_key(system_prompt: str, user_prompt: str, model: str) -> str:
+        """Create a deterministic cache key from prompt components."""
+        content = f"{system_prompt}\x00{user_prompt}\x00{model}"
+        return hashlib.sha256(content.encode()).hexdigest()[:32]
+
+    def get(
+        self, system_prompt: str, user_prompt: str, model: str
+    ) -> Optional[CacheEntry]:
+        """
+        Look up a cached response.
+
+        Returns CacheEntry if found and not expired, None otherwise.
+        """
+        if not self.enabled:
+            return None
+
+        self._ensure_loaded()
+        key = self._make_key(system_prompt, user_prompt, model)
+        entry = self._cache.get(key)
+
+        if entry is None:
+            self._stats.total_misses += 1
+            return None
+
+        if entry.is_expired():
+            del self._cache[key]
+            self._stats.total_misses += 1
+            self._stats.evictions += 1
+            return None
+
+        # Cache hit
+        entry.hit_count += 1
+        self._stats.total_hits += 1
+        self._stats.total_cost_saved += entry.estimated_cost_saved
+        return entry
+
+    def put(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        response_text: str,
+        provider: str = "",
+        estimated_cost: float = 0.0,
+        ttl: Optional[float] = None,
+    ) -> str:
+        """
+        Cache an LLM response.
+
+        Returns the cache key.
+        """
+        if not self.enabled:
+            return ""
+
+        self._ensure_loaded()
+        key = self._make_key(system_prompt, user_prompt, model)
+
+        # Evict if at capacity (remove oldest entry)
+        if len(self._cache) >= self.max_entries and key not in self._cache:
+            self._evict_oldest()
+
+        entry = CacheEntry(
+            prompt_hash=key,
+            response_text=response_text,
+            model=model,
+            provider=provider,
+            created_at=time.time(),
+            ttl_seconds=ttl if ttl is not None else self.default_ttl,
+            estimated_cost_saved=estimated_cost,
+        )
+        self._cache[key] = entry
+        self._stats.total_entries = len(self._cache)
+        return key
+
+    def invalidate(self, system_prompt: str, user_prompt: str, model: str) -> bool:
+        """Remove a specific entry from cache. Returns True if found."""
+        self._ensure_loaded()
+        key = self._make_key(system_prompt, user_prompt, model)
+        if key in self._cache:
+            del self._cache[key]
+            self._stats.total_entries = len(self._cache)
+            return True
+        return False
+
+    def clear(self) -> int:
+        """Clear all cache entries. Returns number of entries removed."""
+        self._ensure_loaded()
+        count = len(self._cache)
+        self._cache.clear()
+        self._stats.total_entries = 0
+        return count
+
+    def get_stats(self) -> dict:
+        """Get cache performance statistics."""
+        self._ensure_loaded()
+        self._stats.total_entries = len(self._cache)
+        return self._stats.to_dict()
+
+    def save_to_disk(self) -> bool:
+        """Persist cache to disk."""
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_file = self.cache_dir / "cache.json"
+            stats_file = self.cache_dir / "stats.json"
+
+            # Save cache entries
+            cache_data = {
+                key: entry.to_dict() for key, entry in self._cache.items()
+            }
+            cache_file.write_text(json.dumps(cache_data, indent=2))
+
+            # Save stats
+            stats_file.write_text(json.dumps(self._stats.to_dict(), indent=2))
+
+            return True
+        except Exception:
+            return False
+
+    def _load_from_disk(self):
+        """Load cache from disk."""
+        cache_file = self.cache_dir / "cache.json"
+        stats_file = self.cache_dir / "stats.json"
+
+        if cache_file.exists():
+            try:
+                data = json.loads(cache_file.read_text())
+                for key, entry_data in data.items():
+                    entry = CacheEntry.from_dict(entry_data)
+                    if not entry.is_expired():
+                        self._cache[key] = entry
+            except (json.JSONDecodeError, Exception):
+                pass
+
+        if stats_file.exists():
+            try:
+                stats_data = json.loads(stats_file.read_text())
+                self._stats.total_hits = stats_data.get("total_hits", 0)
+                self._stats.total_misses = stats_data.get("total_misses", 0)
+                self._stats.total_cost_saved = stats_data.get("total_cost_saved", 0.0)
+                self._stats.evictions = stats_data.get("evictions", 0)
+            except (json.JSONDecodeError, Exception):
+                pass
+
+        self._stats.total_entries = len(self._cache)
+
+    def _evict_oldest(self):
+        """Evict the oldest cache entry."""
+        if not self._cache:
+            return
+        oldest_key = min(self._cache, key=lambda k: self._cache[k].created_at)
+        del self._cache[oldest_key]
+        self._stats.evictions += 1
+
+    def cleanup_expired(self) -> int:
+        """Remove all expired entries. Returns count removed."""
+        self._ensure_loaded()
+        expired_keys = [
+            key for key, entry in self._cache.items() if entry.is_expired()
+        ]
+        for key in expired_keys:
+            del self._cache[key]
+        self._stats.evictions += len(expired_keys)
+        self._stats.total_entries = len(self._cache)
+        return len(expired_keys)
+
+
+def wrap_cognition_with_cache(cognition_engine, cache: PromptCache):
+    """
+    Monkey-patch a CognitionEngine to use prompt caching.
+
+    This wraps the think() method to check cache before calling the LLM.
+    Saves significant API costs for repeated or similar prompts.
+
+    Usage:
+        from singularity.prompt_cache import PromptCache, wrap_cognition_with_cache
+        
+        cache = PromptCache()
+        wrap_cognition_with_cache(agent.cognition, cache)
+        # Now agent.cognition.think() will use cache automatically
+    """
+    from singularity.cognition import Decision, Action, TokenUsage, calculate_api_cost
+
+    original_think = cognition_engine.think
+
+    async def cached_think(state):
+        # Build the same prompts that think() would build
+        system_prompt = cognition_engine.get_system_prompt()
+        tools_text = "\n".join([
+            f"- {t['name']}: {t['description']}" for t in state.tools
+        ])
+        recent_text = ""
+        if state.recent_actions:
+            recent_text = "\nRecent actions:\n" + "\n".join([
+                f"- {a['tool']}: {a.get('result', {}).get('status', 'unknown')}"
+                for a in state.recent_actions[-5:]
+            ])
+
+        user_prompt = f"""Current state:
+- Balance: ${state.balance:.4f}
+- Burn rate: ${state.burn_rate:.6f}/cycle
+- Runway: {state.runway_hours:.1f} hours
+- Cycle: {state.cycle}
+
+Available tools:
+{tools_text}
+{recent_text}
+
+{state.project_context}
+
+What action should you take? Respond with JSON: {{"tool": "skill:action", "params": {{}}, "reasoning": "why"}}"""
+
+        model = cognition_engine.llm_model
+
+        # Check cache
+        cached = cache.get(system_prompt, user_prompt, model)
+        if cached:
+            print(f"[CACHE] HIT - saved ~${cached.estimated_cost_saved:.6f}")
+            action = cognition_engine._parse_action(cached.response_text)
+            return Decision(
+                action=action,
+                reasoning=f"[CACHED] {action.reasoning}",
+                token_usage=TokenUsage(),  # No tokens used
+                api_cost_usd=0.0,  # No API cost
+            )
+
+        # Cache miss - call original think()
+        decision = await original_think(state)
+
+        # Estimate cost for future cache hits
+        estimated_cost = decision.api_cost_usd
+
+        # Cache the response (we need to reconstruct what the LLM said)
+        # Store the action as JSON so _parse_action can parse it back
+        response_json = json.dumps({
+            "tool": decision.action.tool,
+            "params": decision.action.params,
+            "reasoning": decision.action.reasoning,
+        })
+        cache.put(
+            system_prompt,
+            user_prompt,
+            model,
+            response_json,
+            provider=cognition_engine.llm_type,
+            estimated_cost=estimated_cost,
+        )
+
+        return decision
+
+    cognition_engine.think = cached_think
+    cognition_engine._prompt_cache = cache
+    print("[CACHE] Prompt caching enabled")

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1,0 +1,143 @@
+"""Tests for PromptCache."""
+
+import json
+import time
+import tempfile
+import pytest
+from singularity.prompt_cache import PromptCache, CacheEntry, CacheStats
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return PromptCache(cache_dir=str(tmp_path / "cache"), max_entries=10, default_ttl=60.0)
+
+
+class TestCacheEntry:
+    def test_not_expired(self):
+        entry = CacheEntry("abc", "response", "model", "prov", time.time(), 60.0)
+        assert not entry.is_expired()
+
+    def test_expired(self):
+        entry = CacheEntry("abc", "response", "model", "prov", time.time() - 120, 60.0)
+        assert entry.is_expired()
+
+    def test_no_ttl_never_expires(self):
+        entry = CacheEntry("abc", "response", "model", "prov", time.time() - 999999, 0)
+        assert not entry.is_expired()
+
+    def test_roundtrip(self):
+        entry = CacheEntry("abc", "response", "model", "prov", 1000.0, 60.0, 5, 0.01)
+        d = entry.to_dict()
+        restored = CacheEntry.from_dict(d)
+        assert restored.prompt_hash == "abc"
+        assert restored.hit_count == 5
+
+
+class TestCacheStats:
+    def test_hit_rate_empty(self):
+        stats = CacheStats()
+        assert stats.hit_rate == 0.0
+
+    def test_hit_rate(self):
+        stats = CacheStats(total_hits=3, total_misses=7)
+        assert stats.hit_rate == 0.3
+
+    def test_to_dict(self):
+        stats = CacheStats(total_hits=10, total_misses=5)
+        d = stats.to_dict()
+        assert d["hit_rate"] == 0.6667
+
+
+class TestPromptCache:
+    def test_miss_returns_none(self, cache):
+        assert cache.get("sys", "user", "model") is None
+
+    def test_put_and_get(self, cache):
+        cache.put("sys", "user", "model", "response", estimated_cost=0.01)
+        entry = cache.get("sys", "user", "model")
+        assert entry is not None
+        assert entry.response_text == "response"
+
+    def test_different_prompts_different_keys(self, cache):
+        cache.put("sys", "user1", "model", "resp1")
+        cache.put("sys", "user2", "model", "resp2")
+        assert cache.get("sys", "user1", "model").response_text == "resp1"
+        assert cache.get("sys", "user2", "model").response_text == "resp2"
+
+    def test_different_models_different_keys(self, cache):
+        cache.put("sys", "user", "gpt-4", "resp_gpt")
+        cache.put("sys", "user", "claude", "resp_claude")
+        assert cache.get("sys", "user", "gpt-4").response_text == "resp_gpt"
+        assert cache.get("sys", "user", "claude").response_text == "resp_claude"
+
+    def test_expired_entry_returns_none(self, cache):
+        cache.put("sys", "user", "model", "response", ttl=0.01)
+        time.sleep(0.02)
+        assert cache.get("sys", "user", "model") is None
+
+    def test_stats_tracking(self, cache):
+        cache.put("sys", "user", "model", "response", estimated_cost=0.005)
+        cache.get("sys", "user", "model")  # hit
+        cache.get("sys", "other", "model")  # miss
+        stats = cache.get_stats()
+        assert stats["total_hits"] == 1
+        assert stats["total_misses"] == 1
+        assert stats["total_cost_saved"] == 0.005
+
+    def test_invalidate(self, cache):
+        cache.put("sys", "user", "model", "response")
+        assert cache.invalidate("sys", "user", "model")
+        assert cache.get("sys", "user", "model") is None
+        assert not cache.invalidate("sys", "user", "model")
+
+    def test_clear(self, cache):
+        cache.put("sys", "u1", "m", "r1")
+        cache.put("sys", "u2", "m", "r2")
+        removed = cache.clear()
+        assert removed == 2
+        assert cache.get("sys", "u1", "m") is None
+
+    def test_eviction_at_capacity(self, cache):
+        # Fill cache (max_entries=10)
+        for i in range(10):
+            cache.put("sys", f"user_{i}", "model", f"resp_{i}")
+        # Add one more - should evict oldest
+        cache.put("sys", "user_new", "model", "resp_new")
+        stats = cache.get_stats()
+        assert stats["total_entries"] == 10
+        assert stats["evictions"] >= 1
+
+    def test_persistence(self, tmp_path):
+        cache_dir = str(tmp_path / "persist")
+        c1 = PromptCache(cache_dir=cache_dir, default_ttl=3600)
+        c1.put("sys", "user", "model", "response", estimated_cost=0.01)
+        c1.get("sys", "user", "model")  # record a hit
+        c1.save_to_disk()
+
+        c2 = PromptCache(cache_dir=cache_dir, default_ttl=3600)
+        entry = c2.get("sys", "user", "model")
+        assert entry is not None
+        assert entry.response_text == "response"
+        stats = c2.get_stats()
+        assert stats["total_hits"] >= 1
+
+    def test_disabled_cache(self, tmp_path):
+        cache = PromptCache(cache_dir=str(tmp_path), enabled=False)
+        result = cache.put("sys", "user", "model", "response")
+        assert result == ""
+        assert cache.get("sys", "user", "model") is None
+
+    def test_cleanup_expired(self, cache):
+        cache.put("sys", "u1", "model", "r1", ttl=0.01)
+        cache.put("sys", "u2", "model", "r2", ttl=3600)
+        time.sleep(0.02)
+        removed = cache.cleanup_expired()
+        assert removed == 1
+        assert cache.get("sys", "u2", "model") is not None
+
+    def test_hit_count_increments(self, cache):
+        cache.put("sys", "user", "model", "response")
+        cache.get("sys", "user", "model")
+        cache.get("sys", "user", "model")
+        entry = cache.get("sys", "user", "model")
+        assert entry.hit_count == 3


### PR DESCRIPTION
## Summary

Adds a **PromptCache** module that caches LLM responses to reduce API costs — the agent's primary survival expense. When the agent encounters identical prompts (same system prompt + user prompt + model), it returns the cached response instantly at zero cost.

## Pillar: Self-Improvement + Revenue (Cost Reduction)

This directly improves agent survival by reducing API spend. Every cache hit saves money, extending the agent's runway. The cache also tracks statistics so the agent can measure its own efficiency.

## What's Included

### `singularity/prompt_cache.py`
- **`PromptCache`** — Core cache with SHA-256 key generation
  - Exact-match caching keyed by `(system_prompt, user_prompt, model)` 
  - TTL-based expiration (default: 1 hour)
  - LRU eviction when cache reaches max capacity
  - File-backed persistence across agent restarts
  - Cost savings tracking with hit rate statistics
  - Enable/disable toggle
  - `cleanup_expired()` for maintenance

- **`CacheEntry`** — Individual cached response with metadata
- **`CacheStats`** — Performance tracking (hits, misses, hit rate, cost saved)

- **`wrap_cognition_with_cache()`** — Zero-change integration function
  - Monkey-patches `CognitionEngine.think()` to check cache first
  - Automatically caches new responses after LLM calls
  - Tracks estimated cost savings per cache hit
  - Prints `[CACHE] HIT` logs for visibility

### Usage
```python
from singularity.prompt_cache import PromptCache, wrap_cognition_with_cache

# Create cache (persisted to disk)
cache = PromptCache(cache_dir="./data/prompt_cache", max_entries=1000)

# Wire into agent's cognition engine
wrap_cognition_with_cache(agent.cognition, cache)

# Agent now caches LLM responses automatically
# Check savings anytime:
print(cache.get_stats())
# {'total_hits': 42, 'total_misses': 100, 'total_cost_saved': 0.126, 'hit_rate': 0.2958}
```

### Tests — 20 tests covering:
- Cache entry creation, expiration, serialization
- Cache stats and hit rate calculation
- Put/get with different prompts and models
- TTL expiration and LRU eviction
- Disk persistence and recovery
- Disable toggle
- Hit count tracking
- Cleanup of expired entries

## Why This Matters

The agent's #1 expense is LLM API calls. In repetitive scenarios (checking the same files, re-analyzing state), the agent often generates nearly identical prompts. Caching these responses:
- **Reduces API cost** — cached responses cost $0
- **Speeds up response time** — cache lookup is instant vs. ~1-2s API call
- **Extends runway** — more cycles for the same budget
- **Provides analytics** — cache stats show optimization opportunities