### PR TITLE
Add lazy skill loading for resilient agent startup

### DIFF
--- a/singularity/skills/__init__.py
+++ b/singularity/skills/__init__.py
@@ -3,25 +3,49 @@ WisentBot Skills - Modular capabilities for autonomous agents.
 
 Skills provide specific capabilities that agents can use to interact
 with the world. Each skill has a manifest describing its actions.
+
+Skills are lazily imported to avoid crashes from missing optional
+dependencies. Use ``from singularity.skills.base import Skill`` for
+the base class, or import individual skills directly.
 """
 
 from .base import Skill, SkillRegistry, SkillManifest, SkillAction, SkillResult
-from .browser import BrowserSkill
-from .content import ContentCreationSkill
-from .email import EmailSkill
-from .filesystem import FilesystemSkill
-from .github import GitHubSkill
-from .mcp_client import MCPClientSkill
-from .namecheap import NamecheapSkill
-from .request import RequestSkill
-from .shell import ShellSkill
-from .twitter import TwitterSkill
-from .vercel import VercelSkill
-from .self_modify import SelfModifySkill
-from .steering import SteeringSkill
-from .memory import MemorySkill
-from .orchestrator import OrchestratorSkill
-from .crypto import CryptoSkill
+
+# Lazy imports: individual skills are imported on first access so that
+# a missing optional dependency (e.g. seleniumbase, web3) doesn't
+# prevent the entire package from loading.
+
+_LAZY_IMPORTS = {
+    "BrowserSkill": ".browser",
+    "ContentCreationSkill": ".content",
+    "EmailSkill": ".email",
+    "FilesystemSkill": ".filesystem",
+    "GitHubSkill": ".github",
+    "MCPClientSkill": ".mcp_client",
+    "NamecheapSkill": ".namecheap",
+    "RequestSkill": ".request",
+    "ShellSkill": ".shell",
+    "TwitterSkill": ".twitter",
+    "VercelSkill": ".vercel",
+    "SelfModifySkill": ".self_modify",
+    "SteeringSkill": ".steering",
+    "MemorySkill": ".memory",
+    "OrchestratorSkill": ".orchestrator",
+    "CryptoSkill": ".crypto",
+}
+
+
+def __getattr__(name):
+    """Lazily import skill classes on first access."""
+    if name in _LAZY_IMPORTS:
+        import importlib
+        module = importlib.import_module(_LAZY_IMPORTS[name], package=__name__)
+        cls = getattr(module, name)
+        # Cache in module namespace for subsequent accesses
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Base
@@ -30,7 +54,7 @@ __all__ = [
     "SkillManifest",
     "SkillAction",
     "SkillResult",
-    # Skills
+    # Skills (lazily loaded)
     "BrowserSkill",
     "ContentCreationSkill",
     "EmailSkill",

--- a/tests/test_lazy_skill_loading.py
+++ b/tests/test_lazy_skill_loading.py
@@ -1,0 +1,72 @@
+"""Tests for lazy skill loading in autonomous_agent.py and skills/__init__.py."""
+import importlib
+import sys
+import pytest
+
+
+def test_skills_init_imports_base_eagerly():
+    """Base classes should always be available."""
+    from singularity.skills import Skill, SkillRegistry, SkillManifest
+    assert Skill is not None
+    assert SkillRegistry is not None
+
+
+def test_skills_init_lazy_getattr():
+    """__getattr__ should lazily load skill classes."""
+    from singularity.skills import FilesystemSkill
+    assert FilesystemSkill is not None
+    assert hasattr(FilesystemSkill, 'execute')
+
+
+def test_skills_init_unknown_attr_raises():
+    """Accessing a non-existent attribute should raise AttributeError."""
+    import singularity.skills as skills_mod
+    with pytest.raises(AttributeError):
+        _ = skills_mod.NoSuchSkill
+
+
+def test_skill_modules_registry_exists():
+    """SKILL_MODULES registry should be importable."""
+    from singularity.autonomous_agent import SKILL_MODULES
+    assert isinstance(SKILL_MODULES, list)
+    assert len(SKILL_MODULES) >= 10  # at least 10 skills registered
+
+
+def test_skill_modules_entries_are_tuples():
+    """Each entry should be (module_path, class_name)."""
+    from singularity.autonomous_agent import SKILL_MODULES
+    for entry in SKILL_MODULES:
+        assert isinstance(entry, tuple)
+        assert len(entry) == 2
+        module_path, class_name = entry
+        assert module_path.startswith("singularity.skills.")
+        assert class_name.endswith("Skill")
+
+
+def test_load_skill_class_valid():
+    """_load_skill_class should successfully load a skill with no deps."""
+    from singularity.autonomous_agent import AutonomousAgent
+    agent = AutonomousAgent.__new__(AutonomousAgent)
+    # Need _log for _load_skill_class
+    agent._log = lambda tag, msg: None
+    cls = agent._load_skill_class("singularity.skills.filesystem", "FilesystemSkill")
+    assert cls is not None
+    assert cls.__name__ == "FilesystemSkill"
+
+
+def test_load_skill_class_invalid_module():
+    """_load_skill_class should return None for non-existent modules."""
+    from singularity.autonomous_agent import AutonomousAgent
+    agent = AutonomousAgent.__new__(AutonomousAgent)
+    agent._log = lambda tag, msg: None
+    cls = agent._load_skill_class("singularity.skills.nonexistent", "FakeSkill")
+    assert cls is None
+
+
+def test_load_skill_class_invalid_class():
+    """_load_skill_class should return None for non-existent class in valid module."""
+    from singularity.autonomous_agent import AutonomousAgent
+    agent = AutonomousAgent.__new__(AutonomousAgent)
+    agent._log = lambda tag, msg: None
+    cls = agent._load_skill_class("singularity.skills.filesystem", "NonexistentSkill")
+    assert cls is None


### PR DESCRIPTION
## Summary

Replace hardcoded skill imports with lazy loading so the agent can start even when optional dependencies are missing.

## Problem

All 16 skills were imported at module level in both `autonomous_agent.py` and `skills/__init__.py`. If **any** skill's optional dependency was missing (e.g., `seleniumbase` for BrowserSkill, `web3` for CryptoSkill, `tweepy` for TwitterSkill), the entire `autonomous_agent` module would fail to import with an `ImportError`. This made the agent extremely fragile — it required **all** optional dependencies to be installed even if you only needed basic filesystem/shell skills.

## Solution

### 1. `autonomous_agent.py` — Lazy skill imports via registry
- Replaced 16 top-level skill imports with a `SKILL_MODULES` registry (list of `(module_path, class_name)` tuples)
- Added `_load_skill_class()` method that uses `importlib.import_module()` for safe runtime import
- **Missing dependencies are now logged instead of silently swallowed** — no more `except Exception: pass`
- Refactored wiring hooks into a clean dictionary dispatch pattern (`wiring_hooks` dict)
- Added startup summary: `"Loaded N skills, skipped M"`

### 2. `skills/__init__.py` — Module-level `__getattr__` lazy imports
- Replaced eager imports of all 16 skills with a `__getattr__` function using Python 3.7+ module-level lazy loading
- `from singularity.skills import FilesystemSkill` still works but only imports that one module
- Base classes (`Skill`, `SkillRegistry`, etc.) are still eagerly imported

### 3. Tests
- 8 focused tests covering lazy loading behavior, error handling, and the SKILL_MODULES registry

## Before/After

**Before:** Agent crashes if `pip install seleniumbase` wasn't run
```
ImportError: No module named 'seleniumbase'
```

**After:** Agent starts with available skills, logs what's missing
```
[SKILL] - BrowserSkill: missing dependency (No module named 'seleniumbase')
[SKILL] + Filesystem Operations
[SKILL] + Shell Commands
[SKILL] Loaded 5 skills, skipped 11
```

## Pillars

- **Self-Improvement**: More robust agent that logs diagnostic info about its own startup
- **Replication**: Agents can now start in minimal environments without all optional dependencies — critical for spawning lightweight replicas