### PR TITLE
Fix variable scoping bug in run() — UnboundLocalError when performance_tracker disabled

### DIFF
--- a/singularity/autonomous_agent.py
+++ b/singularity/autonomous_agent.py
@@ -695,14 +695,17 @@ PerformanceOptimizerSkill,
             # Track created resources
             self._track_created_resource(decision.action.tool, decision.action.params, result)
 
+            # Parse skill_id and action_name from tool string for use by
+            # performance_tracker, error_recovery, and resource_watcher below
+            skill_id, action_name = '', ''
+            if ':' in decision.action.tool:
+                parts = decision.action.tool.split(':', 1)
+                skill_id, action_name = parts[0], parts[1]
+            else:
+                skill_id = decision.action.tool
+
             # Auto-record performance for cross-session analytics
             if self._performance_tracker:
-                skill_id, action_name = '', ''
-                if ':' in decision.action.tool:
-                    parts = decision.action.tool.split(':', 1)
-                    skill_id, action_name = parts[0], parts[1]
-                else:
-                    skill_id = decision.action.tool
                 self._performance_tracker.record_outcome(
                     skill_id=skill_id,
                     action=action_name,


### PR DESCRIPTION
## Summary
- Fixes a real bug where `skill_id` and `action_name` variables are defined inside `if self._performance_tracker:` but referenced by `_error_recovery` and `_resource_watcher` blocks **outside** that conditional
- When `_performance_tracker` is `None` but `_error_recovery` or `_resource_watcher` is enabled → **`UnboundLocalError`** at runtime
- Moves tool-string parsing (skill_id/action_name extraction) before all three conditional blocks so variables are always defined

## Bug Details
In `autonomous_agent.py` line ~699-731 (before fix):
```python
if self._performance_tracker:
    skill_id, action_name = '', ''  # ← defined HERE
    ...

if self._error_recovery and not exec_success:
    err_skill_id = skill_id  # ← NameError if above block skipped!
    ...

if self._resource_watcher:
    rw_skill_id = skill_id  # ← NameError if above block skipped!
```

## Fix
Move `skill_id`/`action_name` parsing **before** all three conditional blocks.

## Discovery
This bug was found via the comprehensive test suite in PR #203 — two tests specifically document this issue.

## Test plan
- [x] Verified fix logic with direct Python execution
- [x] Lint check passes (no new errors introduced)
- [x] Minimal diff — only moves 6 lines out of conditional, adds comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)