### PR TITLE
Add 3 new revenue sources to RevenueAnalyticsDashboardSkill (#1 priority from MEMORY)

### DIFF
--- a/singularity/skills/revenue_analytics_dashboard.py
+++ b/singularity/skills/revenue_analytics_dashboard.py
@@ -27,6 +27,9 @@ Data sources:
   - marketplace.json: orders, revenue_log
   - hosted_services.json: services with revenue data
   - revenue_catalog.json: products, deployments
+  - database_revenue_bridge.json: paid data analysis, schema design, reports
+  - http_revenue_bridge.json: paid HTTP proxy, webhook relay, health checks
+  - usage.json (api_marketplace): external API brokering, subscriptions
 
 Pillar: Revenue Generation (primary), Goal Setting (data-driven prioritization)
 """
@@ -52,6 +55,9 @@ SOURCE_FILES = {
     "marketplace": DATA_DIR / "marketplace.json",
     "hosted_services": DATA_DIR / "hosted_services.json",
     "revenue_catalog": DATA_DIR / "revenue_catalog.json",
+    "database_revenue_bridge": DATA_DIR / "database_revenue_bridge.json",
+    "http_revenue_bridge": DATA_DIR / "http_revenue_bridge.json",
+    "api_marketplace": DATA_DIR / "usage.json",
 }
 
 MAX_SNAPSHOTS = 200
@@ -369,6 +375,84 @@ class RevenueAnalyticsDashboardSkill(Skill):
         else:
             collected["sources_missing"].append("revenue_catalog")
 
+        # 8. DatabaseRevenueBridge
+        drb = _load_json(SOURCE_FILES["database_revenue_bridge"])
+        if drb:
+            collected["sources_available"].append("database_revenue_bridge")
+            rev_data = drb.get("revenue", {})
+            stats = drb.get("stats", {})
+            rev = rev_data.get("total", 0.0)
+            jobs = drb.get("jobs", [])
+            # Estimate cost as 10% of revenue (compute cost for DB queries)
+            cost = rev * 0.1
+            collected["by_source"]["database_revenue_bridge"] = {
+                "revenue": rev, "cost": cost, "profit": rev - cost,
+                "transactions": stats.get("total_requests", 0),
+                "successful_requests": stats.get("successful_requests", 0),
+                "failed_requests": stats.get("failed_requests", 0),
+                "success_rate": (
+                    round(stats.get("successful_requests", 0) / stats["total_requests"] * 100, 1)
+                    if stats.get("total_requests", 0) > 0 else 0
+                ),
+                "revenue_by_service": rev_data.get("by_service", {}),
+                "reports_generated": len(drb.get("reports", {})),
+                "schemas_created": len(drb.get("schemas_created", {})),
+            }
+            collected["total_revenue"] += rev
+            collected["total_cost"] += cost
+            collected["total_transactions"] += stats.get("total_requests", 0)
+            for cid in rev_data.get("by_customer", {}):
+                collected["customers"].add(cid)
+        else:
+            collected["sources_missing"].append("database_revenue_bridge")
+
+        # 9. HTTPRevenueBridge
+        hrb = _load_json(SOURCE_FILES["http_revenue_bridge"])
+        if hrb:
+            collected["sources_available"].append("http_revenue_bridge")
+            rev_data = hrb.get("revenue", {})
+            stats = hrb.get("stats", {})
+            rev = rev_data.get("total", 0.0)
+            cost = rev * 0.05  # Low cost for HTTP proxying
+            collected["by_source"]["http_revenue_bridge"] = {
+                "revenue": rev, "cost": cost, "profit": rev - cost,
+                "transactions": stats.get("total_requests", 0),
+                "successful_requests": stats.get("successful_requests", 0),
+                "failed_requests": stats.get("failed_requests", 0),
+                "success_rate": (
+                    round(stats.get("successful_requests", 0) / stats["total_requests"] * 100, 1)
+                    if stats.get("total_requests", 0) > 0 else 0
+                ),
+                "revenue_by_service": rev_data.get("by_service", {}),
+            }
+            collected["total_revenue"] += rev
+            collected["total_cost"] += cost
+            collected["total_transactions"] += stats.get("total_requests", 0)
+            for cid in rev_data.get("by_customer", {}):
+                collected["customers"].add(cid)
+        else:
+            collected["sources_missing"].append("http_revenue_bridge")
+
+        # 10. APIMarketplace
+        amp = _load_json(SOURCE_FILES["api_marketplace"])
+        if amp:
+            collected["sources_available"].append("api_marketplace")
+            rev_data = amp.get("revenue", {})
+            rev = rev_data.get("total", 0.0)
+            cost = rev * 0.15  # Higher cost for external API calls
+            collected["by_source"]["api_marketplace"] = {
+                "revenue": rev, "cost": cost, "profit": rev - cost,
+                "transactions": amp.get("total_calls", 0),
+                "revenue_by_api": rev_data.get("by_api", {}),
+            }
+            collected["total_revenue"] += rev
+            collected["total_cost"] += cost
+            collected["total_transactions"] += amp.get("total_calls", 0)
+            for cid in rev_data.get("by_customer", {}):
+                collected["customers"].add(cid)
+        else:
+            collected["sources_missing"].append("api_marketplace")
+
         # Convert set to count
         collected["customer_count"] = len(collected["customers"])
         collected["customers"] = list(collected["customers"])
@@ -548,6 +632,41 @@ class RevenueAnalyticsDashboardSkill(Skill):
                     if q.get("status") == "completed":
                         customer_details[cid]["total_revenue"] += q.get("revenue", q.get("price", 0))
                         customer_details[cid]["total_requests"] += 1
+
+        # Also from database revenue bridge
+        drb = _load_json(SOURCE_FILES["database_revenue_bridge"])
+        if drb:
+            for cid, rev in drb.get("revenue", {}).get("by_customer", {}).items():
+                if cid not in customer_details:
+                    customer_details[cid] = {
+                        "tier": "data_services", "total_revenue": 0,
+                        "total_requests": 0, "registered_at": "",
+                    }
+                customer_details[cid]["total_revenue"] += rev
+                customer_jobs = [j for j in drb.get("jobs", []) if j.get("customer_id") == cid]
+                customer_details[cid]["total_requests"] += len(customer_jobs)
+
+        # Also from HTTP revenue bridge
+        hrb = _load_json(SOURCE_FILES["http_revenue_bridge"])
+        if hrb:
+            for cid, rev in hrb.get("revenue", {}).get("by_customer", {}).items():
+                if cid not in customer_details:
+                    customer_details[cid] = {
+                        "tier": "http_services", "total_revenue": 0,
+                        "total_requests": 0, "registered_at": "",
+                    }
+                customer_details[cid]["total_revenue"] += rev
+
+        # Also from API marketplace
+        amp = _load_json(SOURCE_FILES["api_marketplace"])
+        if amp:
+            for cid, rev in amp.get("revenue", {}).get("by_customer", {}).items():
+                if cid not in customer_details:
+                    customer_details[cid] = {
+                        "tier": "api_marketplace", "total_revenue": 0,
+                        "total_requests": 0, "registered_at": "",
+                    }
+                customer_details[cid]["total_revenue"] += rev
 
         # Sort by revenue
         sorted_customers = sorted(

--- a/singularity/skills/revenue_analytics_dashboard.py
+++ b/singularity/skills/revenue_analytics_dashboard.py
@@ -382,7 +382,6 @@ class RevenueAnalyticsDashboardSkill(Skill):
             rev_data = drb.get("revenue", {})
             stats = drb.get("stats", {})
             rev = rev_data.get("total", 0.0)
-            jobs = drb.get("jobs", [])
             # Estimate cost as 10% of revenue (compute cost for DB queries)
             cost = rev * 0.1
             collected["by_source"]["database_revenue_bridge"] = {

--- a/tests/test_revenue_dashboard_new_sources.py
+++ b/tests/test_revenue_dashboard_new_sources.py
@@ -1,0 +1,167 @@
+"""Tests for new revenue sources in RevenueAnalyticsDashboardSkill."""
+
+import json
+import pytest
+import asyncio
+
+from singularity.skills.revenue_analytics_dashboard import (
+    RevenueAnalyticsDashboardSkill,
+    DASHBOARD_FILE,
+    DATA_DIR,
+    SOURCE_FILES,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_data(tmp_path, monkeypatch):
+    monkeypatch.setattr("singularity.skills.revenue_analytics_dashboard.DASHBOARD_FILE", tmp_path / "revenue_analytics_dashboard.json")
+    monkeypatch.setattr("singularity.skills.revenue_analytics_dashboard.DATA_DIR", tmp_path)
+    new_sources = {k: tmp_path / v.name for k, v in SOURCE_FILES.items()}
+    monkeypatch.setattr("singularity.skills.revenue_analytics_dashboard.SOURCE_FILES", new_sources)
+    yield tmp_path
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _write(tmp_path, filename, data):
+    (tmp_path / filename).write_text(json.dumps(data, default=str))
+
+
+def test_database_revenue_bridge_collected(clean_data):
+    """DatabaseRevenueBridge data appears in overview."""
+    _write(clean_data, "database_revenue_bridge.json", {
+        "jobs": [{"id": "j1", "customer_id": "c1", "service": "data_analysis"}],
+        "revenue": {"total": 0.50, "by_service": {"data_analysis": 0.50}, "by_customer": {"c1": 0.50}},
+        "stats": {"total_requests": 10, "successful_requests": 9, "failed_requests": 1},
+        "reports": {"r1": {}},
+        "schemas_created": {"s1": {}},
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("overview", {}))
+    assert result.success
+    assert result.data["total_revenue"] == 0.50
+    assert result.data["sources_active"] == 1
+
+
+def test_http_revenue_bridge_collected(clean_data):
+    """HTTPRevenueBridge data appears in overview."""
+    _write(clean_data, "http_revenue_bridge.json", {
+        "revenue": {"total": 1.20, "by_service": {"proxy_request": 1.0, "webhook_relay": 0.2}, "by_customer": {"c2": 1.20}},
+        "stats": {"total_requests": 25, "successful_requests": 24, "failed_requests": 1},
+        "history": [],
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("overview", {}))
+    assert result.success
+    assert result.data["total_revenue"] == 1.20
+    assert result.data["sources_active"] == 1
+
+
+def test_api_marketplace_collected(clean_data):
+    """APIMarketplace data appears in overview."""
+    _write(clean_data, "usage.json", {
+        "revenue": {"total": 2.00, "by_api": {"weather": 1.5, "geocode": 0.5}, "by_customer": {"c3": 2.0}},
+        "total_calls": 50,
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("overview", {}))
+    assert result.success
+    assert result.data["total_revenue"] == 2.00
+    assert result.data["sources_active"] == 1
+
+
+def test_all_three_new_sources_combined(clean_data):
+    """All 3 new sources aggregate correctly."""
+    _write(clean_data, "database_revenue_bridge.json", {
+        "revenue": {"total": 1.0, "by_service": {}, "by_customer": {"c1": 1.0}},
+        "stats": {"total_requests": 5, "successful_requests": 5, "failed_requests": 0},
+        "reports": {}, "schemas_created": {}, "jobs": [],
+    })
+    _write(clean_data, "http_revenue_bridge.json", {
+        "revenue": {"total": 2.0, "by_service": {}, "by_customer": {"c2": 2.0}},
+        "stats": {"total_requests": 10, "successful_requests": 10, "failed_requests": 0},
+    })
+    _write(clean_data, "usage.json", {
+        "revenue": {"total": 3.0, "by_api": {}, "by_customer": {"c3": 3.0}},
+        "total_calls": 15,
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("overview", {}))
+    assert result.success
+    assert result.data["total_revenue"] == 6.0
+    assert result.data["sources_active"] == 3
+
+
+def test_new_sources_in_by_source(clean_data):
+    """New sources appear in by_source breakdown."""
+    _write(clean_data, "database_revenue_bridge.json", {
+        "revenue": {"total": 0.50, "by_service": {"data_analysis": 0.50}, "by_customer": {}},
+        "stats": {"total_requests": 5, "successful_requests": 4, "failed_requests": 1},
+        "reports": {"r1": {}}, "schemas_created": {}, "jobs": [],
+    })
+    _write(clean_data, "http_revenue_bridge.json", {
+        "revenue": {"total": 0.30, "by_service": {"proxy_request": 0.30}, "by_customer": {}},
+        "stats": {"total_requests": 3, "successful_requests": 3, "failed_requests": 0},
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("by_source", {}))
+    assert result.success
+    assert "database_revenue_bridge" in result.data["sources"]
+    assert "http_revenue_bridge" in result.data["sources"]
+    src = result.data["sources"]["database_revenue_bridge"]
+    assert src["revenue"] == 0.50
+    assert src["reports_generated"] == 1
+
+
+def test_new_sources_customers(clean_data):
+    """Customers from new sources appear in customer analytics."""
+    _write(clean_data, "database_revenue_bridge.json", {
+        "revenue": {"total": 1.0, "by_service": {}, "by_customer": {"db-cust-1": 1.0}},
+        "stats": {"total_requests": 3, "successful_requests": 3, "failed_requests": 0},
+        "reports": {}, "schemas_created": {},
+        "jobs": [
+            {"customer_id": "db-cust-1", "service": "data_analysis"},
+            {"customer_id": "db-cust-1", "service": "report_generation"},
+        ],
+    })
+    _write(clean_data, "http_revenue_bridge.json", {
+        "revenue": {"total": 0.5, "by_service": {}, "by_customer": {"http-cust-1": 0.5}},
+        "stats": {"total_requests": 2, "successful_requests": 2, "failed_requests": 0},
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("customers", {}))
+    assert result.success
+    assert result.data["total_customers"] == 2
+    cust_ids = [c["customer_id"] for c in result.data["top_customers"]]
+    assert "db-cust-1" in cust_ids
+    assert "http-cust-1" in cust_ids
+
+
+def test_mixed_old_and_new_sources(clean_data):
+    """Old and new sources aggregate together correctly."""
+    _write(clean_data, "task_pricing.json", {
+        "revenue_summary": {"total_revenue": 5.0, "total_actual_cost": 2.0, "quote_count": 50},
+    })
+    _write(clean_data, "database_revenue_bridge.json", {
+        "revenue": {"total": 1.0, "by_service": {}, "by_customer": {}},
+        "stats": {"total_requests": 10, "successful_requests": 10, "failed_requests": 0},
+        "reports": {}, "schemas_created": {}, "jobs": [],
+    })
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("overview", {}))
+    assert result.success
+    assert result.data["total_revenue"] == 6.0
+    assert result.data["sources_active"] == 2
+
+
+def test_status_shows_all_sources():
+    """Status action shows all 10 source files."""
+    skill = RevenueAnalyticsDashboardSkill()
+    result = run(skill.execute("status", {}))
+    assert result.success
+    source_names = list(result.data["sources"].keys())
+    assert "database_revenue_bridge" in source_names
+    assert "http_revenue_bridge" in source_names
+    assert "api_marketplace" in source_names


### PR DESCRIPTION
## Summary
- Integrates **DatabaseRevenueBridge**, **HTTPRevenueBridge**, and **APIMarketplace** into the unified revenue analytics dashboard
- Dashboard now aggregates revenue data from **10 sources** (up from 7), giving the agent complete visibility into all revenue streams
- Customer analytics enriched with customer data from all 3 new revenue bridges
- 8 new tests covering individual sources, combined aggregation, by_source breakdown, customer analytics, mixed old+new sources, and status listing

## Pillar: Revenue Generation
The revenue analytics dashboard is the agent's "single pane of glass" for understanding earnings across all services. Without integrating the 3 newest revenue-generating skills (DatabaseRevenueBridge, HTTPRevenueBridge, APIMarketplace), the dashboard had blind spots — revenue from data analysis, HTTP proxy services, and API marketplace was invisible. This PR closes that gap.

## New data sources
| Source | File | Revenue Services |
|--------|------|-----------------|
| DatabaseRevenueBridge | `database_revenue_bridge.json` | Data analysis, schema design, reports |
| HTTPRevenueBridge | `http_revenue_bridge.json` | HTTP proxy, webhook relay, health checks |
| APIMarketplace | `usage.json` | External API brokering, subscriptions |

## Test plan
- [x] 8 new tests in `tests/test_revenue_dashboard_new_sources.py`
- [x] All 14 existing dashboard tests still pass
- [x] All 17 smoke tests pass
- [x] Syntax validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)