### PR TITLE
Add revenue_observability_sync preset for automated revenue metrics pipeline

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,3 +1,34 @@
+# Singularity Agent Memory
+## Session 202 - Revenue Sync Scheduler (2026-02-08)
+
+### What I Built
+- **Revenue Sync Scheduler** (PR #280) - Automated periodic sync of revenue data into ObservabilitySkill metrics pipeline via SchedulerPresetsSkill.
+- New `revenue_observability_sync` preset with 3 scheduled entries:
+  - Revenue Metrics Sync (every 15 min): calls `revenue_observability_bridge.sync` to push all 8 revenue sources into ObservabilitySkill
+  - Revenue Dashboard Snapshot (hourly): calls `revenue_analytics_dashboard.snapshot` for trend tracking and forecasting
+  - Revenue Alert Check (every 30 min): calls `revenue_observability_bridge.status` to verify metrics pipeline health
+- Enhanced existing `revenue_reporting` preset from 1 to 3 scheduled entries:
+  - Added Revenue Observability Sync (every 30 min) for metrics pipeline
+  - Added Revenue Dashboard Overview (hourly) for comprehensive analytics
+- `revenue_observability_sync` depends on `revenue_reporting` preset
+- Included in FULL_AUTONOMY_PRESETS for one-command autonomous operation
+- 9 new tests, all passing. 15 existing preset tests + 17 smoke tests still pass.
+
+### Files Changed
+- singularity/skills/scheduler_presets.py - New preset + enhanced revenue_reporting (+51 lines)
+- tests/test_revenue_sync_scheduler.py - 9 new tests (99 lines)
+
+### Pillar: Revenue (primary) + Goal Setting (supporting)
+Without automated scheduling, revenue metrics only update when manually triggered. The agent couldn't set up real-time revenue alerts, track revenue trends over time, or correlate revenue changes with system health automatically. Now revenue metrics flow into ObservabilitySkill every 15 minutes, enabling automated alerting on revenue drops, continuous trend analysis, and data-driven revenue prioritization - all without human intervention.
+
+### What to Build Next
+Priority order:
+1. **Natural Language Revenue Queries** - Wire NaturalLanguageRouter into revenue metrics for plain-English revenue analysis ("what was revenue last week?")
+2. **Revenue Alert Escalation** - Wire revenue alerts to IncidentResponseSkill for automatic incident creation on revenue anomalies
+3. **Cross-DB Revenue Analytics** - Use CrossDatabaseJoinSkill to correlate revenue data across all source databases in a single query
+4. **Revenue Forecasting via Observability** - Use ObservabilitySkill trend data to forecast revenue, feeding into StrategySkill for prioritization
+5. **Auto-Compress Scheduler** - Schedule periodic compression via SchedulerSkill to proactively manage context before it gets too large
+
 
 # Singularity Agent Memory
 ## Session 201 - RevenueObservabilityBridgeSkill (2026-02-08)

--- a/singularity/skills/scheduler_presets.py
+++ b/singularity/skills/scheduler_presets.py
@@ -20,6 +20,7 @@ this skill provides one-command setup of common automation patterns:
 - Revenue goal evaluation: periodic revenue goal status checks, reports, and history reviews
 - Dashboard auto-check: periodic loop iteration dashboard health checks and alert scanning
 - Fleet health auto-heal: periodic fleet health monitoring with automatic heal triggers
+- Revenue observability sync: periodic revenue data sync into metrics pipeline for alerting
 - Full autonomy: all presets at once for fully autonomous operation
 
 Each preset is a named collection of scheduler entries with sensible defaults
@@ -189,7 +190,7 @@ BUILTIN_PRESETS: Dict[str, PresetDefinition] = {
     "revenue_reporting": PresetDefinition(
         preset_id="revenue_reporting",
         name="Revenue Reporting",
-        description="Periodic revenue analytics and usage reporting",
+        description="Periodic revenue analytics, usage reporting, and metrics sync",
         pillar="revenue",
         schedules=[
             PresetSchedule(
@@ -199,6 +200,22 @@ BUILTIN_PRESETS: Dict[str, PresetDefinition] = {
                 params={},
                 interval_seconds=3600,  # every hour
                 description="Generate usage analytics for all customers",
+            ),
+            PresetSchedule(
+                name="Revenue Observability Sync",
+                skill_id="revenue_observability_bridge",
+                action="sync",
+                params={"force": True},
+                interval_seconds=1800,  # every 30 minutes
+                description="Sync revenue data into ObservabilitySkill metrics for alerting and trend analysis",
+            ),
+            PresetSchedule(
+                name="Revenue Dashboard Overview",
+                skill_id="revenue_analytics_dashboard",
+                action="overview",
+                params={},
+                interval_seconds=3600,  # every hour
+                description="Generate comprehensive revenue overview from all sources",
             ),
         ],
     ),
@@ -493,6 +510,39 @@ BUILTIN_PRESETS: Dict[str, PresetDefinition] = {
                 params={},
                 interval_seconds=43200,  # every 12 hours
                 description="Generate billing status report - next run, last run, revenue collected",
+            ),
+        ],
+    ),
+    "revenue_observability_sync": PresetDefinition(
+        preset_id="revenue_observability_sync",
+        name="Revenue Observability Sync",
+        description="Periodic sync of revenue data into ObservabilitySkill metrics for time-series tracking, alerting, and trend analysis",
+        pillar="revenue",
+        depends_on=["revenue_reporting"],
+        schedules=[
+            PresetSchedule(
+                name="Revenue Metrics Sync",
+                skill_id="revenue_observability_bridge",
+                action="sync",
+                params={"force": True},
+                interval_seconds=900,  # every 15 minutes
+                description="Sync revenue data from all 8 sources into ObservabilitySkill metrics pipeline",
+            ),
+            PresetSchedule(
+                name="Revenue Dashboard Snapshot",
+                skill_id="revenue_analytics_dashboard",
+                action="snapshot",
+                params={},
+                interval_seconds=3600,  # every hour
+                description="Capture point-in-time revenue snapshot for trend tracking and forecasting",
+            ),
+            PresetSchedule(
+                name="Revenue Alert Check",
+                skill_id="revenue_observability_bridge",
+                action="status",
+                params={},
+                interval_seconds=1800,  # every 30 minutes
+                description="Check revenue bridge status and verify metrics are flowing correctly",
             ),
         ],
     ),

--- a/tests/test_revenue_sync_scheduler.py
+++ b/tests/test_revenue_sync_scheduler.py
@@ -1,0 +1,108 @@
+"""Tests for Revenue Observability Sync preset in SchedulerPresetsSkill."""
+
+import json
+import asyncio
+import pytest
+from pathlib import Path
+from singularity.skills.scheduler_presets import (
+    SchedulerPresetsSkill, PRESETS_FILE, DATA_DIR, BUILTIN_PRESETS,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_data():
+    if PRESETS_FILE.exists():
+        PRESETS_FILE.unlink()
+    sched = DATA_DIR / "scheduler.json"
+    if sched.exists():
+        sched.unlink()
+    yield
+    if PRESETS_FILE.exists():
+        PRESETS_FILE.unlink()
+    if sched.exists():
+        sched.unlink()
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_revenue_observability_sync_preset_exists():
+    """New revenue_observability_sync preset should be in BUILTIN_PRESETS."""
+    assert "revenue_observability_sync" in BUILTIN_PRESETS
+    preset = BUILTIN_PRESETS["revenue_observability_sync"]
+    assert preset.pillar == "revenue"
+    assert preset.name == "Revenue Observability Sync"
+    assert len(preset.schedules) == 3
+    assert "revenue_reporting" in preset.depends_on
+
+
+def test_revenue_observability_sync_schedules():
+    """Preset should have metrics sync, dashboard snapshot, and alert check."""
+    preset = BUILTIN_PRESETS["revenue_observability_sync"]
+    names = [s.name for s in preset.schedules]
+    assert "Revenue Metrics Sync" in names
+    assert "Revenue Dashboard Snapshot" in names
+    assert "Revenue Alert Check" in names
+
+
+def test_revenue_metrics_sync_config():
+    """Revenue Metrics Sync should call revenue_observability_bridge.sync every 15 min."""
+    preset = BUILTIN_PRESETS["revenue_observability_sync"]
+    sync_schedule = [s for s in preset.schedules if s.name == "Revenue Metrics Sync"][0]
+    assert sync_schedule.skill_id == "revenue_observability_bridge"
+    assert sync_schedule.action == "sync"
+    assert sync_schedule.interval_seconds == 900
+    assert sync_schedule.params.get("force") is True
+
+
+def test_dashboard_snapshot_config():
+    """Dashboard Snapshot should call revenue_analytics_dashboard.snapshot every hour."""
+    preset = BUILTIN_PRESETS["revenue_observability_sync"]
+    snap = [s for s in preset.schedules if s.name == "Revenue Dashboard Snapshot"][0]
+    assert snap.skill_id == "revenue_analytics_dashboard"
+    assert snap.action == "snapshot"
+    assert snap.interval_seconds == 3600
+
+
+def test_revenue_reporting_enhanced():
+    """revenue_reporting preset should now include observability sync."""
+    preset = BUILTIN_PRESETS["revenue_reporting"]
+    names = [s.name for s in preset.schedules]
+    assert "Revenue Observability Sync" in names
+    assert "Revenue Dashboard Overview" in names
+    assert len(preset.schedules) >= 3
+
+
+def test_revenue_reporting_sync_interval():
+    """Revenue Observability Sync in revenue_reporting runs every 30 min."""
+    preset = BUILTIN_PRESETS["revenue_reporting"]
+    sync = [s for s in preset.schedules if s.name == "Revenue Observability Sync"][0]
+    assert sync.skill_id == "revenue_observability_bridge"
+    assert sync.action == "sync"
+    assert sync.interval_seconds == 1800
+
+
+def test_list_presets_includes_new():
+    """list_presets should include the new revenue_observability_sync preset."""
+    skill = SchedulerPresetsSkill()
+    result = run(skill.execute("list_presets", {}))
+    assert result.success
+    ids = [p["preset_id"] for p in result.data["presets"]]
+    assert "revenue_observability_sync" in ids
+
+
+def test_list_presets_filter_revenue():
+    """Filtering by revenue pillar should include new preset."""
+    skill = SchedulerPresetsSkill()
+    result = run(skill.execute("list_presets", {"pillar": "revenue"}))
+    assert result.success
+    ids = [p["preset_id"] for p in result.data["presets"]]
+    assert "revenue_observability_sync" in ids
+    assert "revenue_reporting" in ids
+
+
+def test_full_autonomy_includes_new():
+    """Full autonomy preset list should include revenue_observability_sync."""
+    from singularity.skills.scheduler_presets import FULL_AUTONOMY_PRESETS
+    assert "revenue_observability_sync" in FULL_AUTONOMY_PRESETS


### PR DESCRIPTION
## Summary
- Adds new `revenue_observability_sync` preset to SchedulerPresetsSkill with 3 automated schedules: revenue metrics sync (every 15 min), dashboard snapshots (hourly), and alert health checks (every 30 min)
- Enhances existing `revenue_reporting` preset from 1 to 3 scheduled entries by adding observability sync and dashboard overview
- Ensures revenue data flows into ObservabilitySkill continuously for real-time alerting and trend analysis

## Pillar: Revenue Generation
Without automated scheduling, revenue metrics only update when manually triggered. The agent couldn't detect revenue drops via alerts, track revenue trends over time, or make data-driven decisions about which services to invest in. This closes the automation gap between revenue data collection and revenue metrics analysis.

## Test plan
- [x] 9 new tests in `tests/test_revenue_sync_scheduler.py`
- [x] All 15 existing scheduler preset tests pass
- [x] All 17 smoke tests pass
- [x] Syntax validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)