### PR TITLE
fix: restore CI workflow and smoke tests deleted by bulk revert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff check
+        run: ruff check singularity/ --select E,F --ignore E501,E402,E721,E731,E741,F401,F841,F541
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short --timeout=30
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ crypto = ["web3>=6.0.0", "eth-account>=0.10.0"]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.0.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
 ]
@@ -85,6 +86,11 @@ where = ["."]
 [tool.black]
 line-length = 100
 target-version = ["py310", "py311", "py312"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+timeout = 30
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,121 @@
+"""Smoke tests that verify basic imports and instantiation work without API keys."""
+
+import pytest
+
+
+class TestImports:
+    """Verify all core modules can be imported."""
+
+    def test_import_package(self):
+        import singularity
+        assert hasattr(singularity, "__version__")
+
+    def test_import_agent(self):
+        from singularity import AutonomousAgent
+        assert AutonomousAgent is not None
+
+    def test_import_cognition(self):
+        from singularity import CognitionEngine, AgentState, Decision, Action, TokenUsage
+        assert all(c is not None for c in [CognitionEngine, AgentState, Decision, Action, TokenUsage])
+
+    def test_import_skill_base(self):
+        from singularity import Skill, SkillRegistry, SkillManifest, SkillAction, SkillResult
+        assert all(c is not None for c in [Skill, SkillRegistry, SkillManifest, SkillAction, SkillResult])
+
+    def test_import_filesystem_skill(self):
+        from singularity.skills.filesystem import FilesystemSkill
+        assert FilesystemSkill is not None
+
+    def test_import_shell_skill(self):
+        from singularity.skills.shell import ShellSkill
+        assert ShellSkill is not None
+
+
+class TestSkillBase:
+    """Test SkillResult, SkillAction, SkillManifest, SkillRegistry."""
+
+    def test_skill_result_defaults(self):
+        from singularity.skills.base import SkillResult
+        r = SkillResult(success=True)
+        assert r.success is True
+        assert r.message == ""
+        assert r.data == {}
+        assert r.cost == 0
+        assert r.revenue == 0
+
+    def test_skill_result_with_data(self):
+        from singularity.skills.base import SkillResult
+        r = SkillResult(success=False, message="error", data={"key": "val"}, cost=0.5)
+        assert r.success is False
+        assert r.message == "error"
+        assert r.data["key"] == "val"
+        assert r.cost == 0.5
+
+    def test_skill_action(self):
+        from singularity.skills.base import SkillAction
+        a = SkillAction(name="test", description="A test action", parameters={"x": {"type": "str"}})
+        assert a.name == "test"
+        assert a.estimated_cost == 0
+        assert a.success_probability == 0.8
+
+    def test_skill_manifest(self):
+        from singularity.skills.base import SkillManifest
+        m = SkillManifest(
+            skill_id="test", name="Test", version="1.0",
+            category="dev", description="Testing", actions=[],
+            required_credentials=[],
+        )
+        assert m.skill_id == "test"
+        assert m.required_credentials == []
+
+    def test_skill_registry(self):
+        from singularity.skills.base import SkillRegistry
+        reg = SkillRegistry()
+        assert reg.list_skills() == []
+        assert reg.list_all_actions() == []
+        assert reg.get("nonexistent") is None
+
+
+class TestCognition:
+    """Test CognitionEngine and data classes."""
+
+    def test_agent_state(self):
+        from singularity.cognition import AgentState
+        state = AgentState(balance=100.0, burn_rate=0.01, runway_hours=1000.0)
+        assert state.balance == 100.0
+        assert state.burn_rate == 0.01
+        assert state.cycle == 0
+
+    def test_cognition_engine_none_provider(self):
+        from singularity.cognition import CognitionEngine
+        engine = CognitionEngine(llm_provider="none")
+        assert engine is not None
+
+    def test_action_dataclass(self):
+        from singularity.cognition import Action
+        a = Action(tool="fs:read", params={"path": "/tmp/x"})
+        assert a.tool == "fs:read"
+        assert a.params["path"] == "/tmp/x"
+
+    def test_token_usage(self):
+        from singularity.cognition import TokenUsage
+        t = TokenUsage(input_tokens=100, output_tokens=50)
+        assert t.input_tokens == 100
+        assert t.output_tokens == 50
+
+
+class TestFilesystemSkill:
+    """Test FilesystemSkill instantiation and actions."""
+
+    def test_instantiation(self):
+        from singularity.skills.filesystem import FilesystemSkill
+        skill = FilesystemSkill()
+        assert skill.manifest.skill_id == "filesystem"
+
+    def test_actions_available(self):
+        from singularity.skills.filesystem import FilesystemSkill
+        skill = FilesystemSkill()
+        action_names = [a.name for a in skill.get_actions()]
+        assert "glob" in action_names
+        assert "view" in action_names
+        assert "write" in action_names


### PR DESCRIPTION
## Summary
- Restores CI workflow (`.github/workflows/ci.yml`) and smoke test suite (`tests/test_smoke.py`) that were accidentally deleted by the bulk revert in #294
- The revert removed 366 agent-created files including the CI infrastructure, leaving the repo with zero quality gates
- All 17 smoke tests pass locally in <1s — they test imports and dataclass instantiation, no API keys needed

## Changes
- **`.github/workflows/ci.yml`** — lint (ruff) + test (Python 3.10/3.11/3.12) + build, with `timeout-minutes: 10` to prevent CI hangs
- **`tests/test_smoke.py`** — 17 smoke tests covering imports, skill base classes, cognition dataclasses, filesystem skill
- **`tests/__init__.py`** — empty init for test package
- **`pyproject.toml`** — restored `[tool.pytest.ini_options]`, added `pytest-timeout>=2.0.0` to dev deps with 30s default timeout

## Test plan
- [x] All 17 smoke tests pass locally (`pytest tests/ -v --tb=short --timeout=30`)
- [x] Lint passes (`ruff check singularity/ --select E,F --ignore E501,E402,E721,E731,E741,F401,F841,F541`)
- [ ] CI should pass on this PR (first CI run since the revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)