### PR TITLE
fix: use AsyncAnthropicVertex and guard broadcast KeyError

### DIFF
--- a/singularity/cognition.py
+++ b/singularity/cognition.py
@@ -55,7 +55,7 @@ except ImportError:
     HAS_ANTHROPIC = False
 
 try:
-    from anthropic import AnthropicVertex
+    from anthropic import AsyncAnthropicVertex
     HAS_VERTEX_CLAUDE = True
 except ImportError:
     HAS_VERTEX_CLAUDE = False
@@ -311,7 +311,7 @@ class CognitionEngine:
         # Initialize the selected backend
         if llm_provider == "vertex":
             if llm_model.startswith("claude") and HAS_VERTEX_CLAUDE:
-                self.llm = AnthropicVertex(project_id=self.vertex_project, region=self.vertex_location)
+                self.llm = AsyncAnthropicVertex(project_id=self.vertex_project, region=self.vertex_location)
                 self.llm_type = "vertex"
             elif HAS_VERTEX_GEMINI:
                 vertexai.init(project=self.vertex_project, location=self.vertex_location)
@@ -618,7 +618,7 @@ What action should you take? Respond with JSON: {{"tool": "skill:action", "param
             )
 
         elif self.llm_type == "vertex":
-            response = self.llm.messages.create(
+            response = await self.llm.messages.create(
                 model=self.llm_model,
                 max_tokens=500,
                 system=system_prompt,

--- a/singularity/skills/orchestrator.py
+++ b/singularity/skills/orchestrator.py
@@ -495,6 +495,8 @@ Now go. Live your life. The clock is ticking.
         sent_to = []
         for agent_id, living in _all_living_agents.items():
             if living.status == LifeStatus.ALIVE and agent_id != self._my_id:
+                if agent_id not in _message_boxes:
+                    _message_boxes[agent_id] = asyncio.Queue()
                 await _message_boxes[agent_id].put({
                     "from_id": self._my_id,
                     "from_name": getattr(self._my_agent, 'name', 'Unknown'),


### PR DESCRIPTION
## Summary
- **cognition.py**: `AnthropicVertex` (sync) was used inside `async def think()`, blocking the event loop during Vertex AI Claude inference. Replaced with `AsyncAnthropicVertex` and added `await` to `messages.create()`.
- **orchestrator.py**: `_broadcast()` accessed `_message_boxes[agent_id]` without checking if the key exists, causing `KeyError` when an agent's message queue wasn't pre-initialized. Added guard to create the queue on demand.

## Test plan
- [x] All module imports verified (`python3 -c "from singularity import ..."`)
- [x] `AsyncAnthropicVertex` confirmed to extend `AsyncAPIClient` (not `SyncAPIClient`)
- [x] No new files created — edits to 2 existing files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)