### PR TITLE
fix: 5 runtime safety guards for agent core + LLM providers

### DIFF
--- a/singularity/cognition/providers.py
+++ b/singularity/cognition/providers.py
@@ -111,6 +111,8 @@ async def generate_with_messages(
             None,
             lambda: engine.llm.generate([prompt], engine.sampling_params)
         )
+        if not outputs or not outputs[0].outputs:
+            return "", TokenUsage()
         output = outputs[0].outputs[0]
         usage = TokenUsage(
             input_tokens=len(outputs[0].prompt_token_ids),
@@ -135,6 +137,8 @@ async def generate_with_messages(
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens
         )
+        if not response.content:
+            return "", usage
         return response.content[0].text, usage
 
     elif engine.llm_type == "vertex":
@@ -149,6 +153,8 @@ async def generate_with_messages(
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens
         )
+        if not response.content:
+            return "", usage
         return response.content[0].text, usage
 
     elif engine.llm_type == "vertex_gemini":
@@ -180,7 +186,9 @@ async def generate_with_messages(
             input_tokens=response.usage.prompt_tokens if response.usage else 0,
             output_tokens=response.usage.completion_tokens if response.usage else 0
         )
-        return response.choices[0].message.content, usage
+        if not response.choices:
+            return "", usage
+        return response.choices[0].message.content or "", usage
 
     return "", TokenUsage()
 


### PR DESCRIPTION
## Summary

Fixes 5 runtime bugs that can crash agents under edge conditions:

| # | Severity | File | Bug | Fix |
|---|----------|------|-----|-----|
| 1 | HIGH | `autonomous_agent.py` | `json.load(open())` leaks file handles | Use context manager (`with open()`) |
| 2 | CRITICAL | `autonomous_agent.py` | `skill.execute()` called without `initialize()` | Check `skill.initialized`, call `initialize()` first |
| 3 | CRITICAL | `providers.py` | `response.content[0]` crashes on empty Anthropic response | Bounds check before access |
| 4 | CRITICAL | `providers.py` | `response.content[0]` crashes on empty Vertex Claude response | Bounds check before access |
| 5 | CRITICAL | `providers.py` | `response.choices[0]` crashes on empty OpenAI response | Bounds check before access |
| 6 | HIGH | `providers.py` | `outputs[0].outputs[0]` crashes on empty vLLM output | Bounds check before access |

### Impact
- **Bug #2** is the most dangerous: skills execute with uninitialized state (credentials not validated, setup not done), leading to silent failures or credential-related crashes
- **Bugs #3-6** crash the entire agent when an LLM returns an empty response (network issues, rate limits, content filtering)
- **Bug #1** leaks file handles on every activity log write, accumulating over long-running agent sessions

### Changes
- `autonomous_agent.py`: 12 lines changed (resource cleanup + skill initialization guard)
- `providers.py`: 10 lines changed (bounds checks on all LLM response accesses)

All fixes are minimal, defensive guards with no behavior changes for normal operation.

## Test plan
- [ ] Verify `_save_activity` and `_mark_stopped` use context managers
- [ ] Verify `_execute` initializes skills before calling `execute()`
- [ ] Verify all LLM providers handle empty responses gracefully

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>