### PR TITLE
fix: broken TikTok imports + bare except clauses in 4 skills

### DIFF
--- a/singularity/skills/builtin/account_creator/twitter.py
+++ b/singularity/skills/builtin/account_creator/twitter.py
@@ -26,7 +26,7 @@ async def create_twitter_account(skill, username: str, email: str,
             await page.get_by_role("button", name="Create account").click()
             await asyncio.sleep(3)
             status = "create_clicked"
-        except:
+        except Exception:
             pass
 
         # Step 2: Click "Use email instead"
@@ -35,7 +35,7 @@ async def create_twitter_account(skill, username: str, email: str,
             if await email_link.count() > 0:
                 await email_link.click()
                 await asyncio.sleep(2)
-        except:
+        except Exception:
             pass
 
         # Step 3: Fill form
@@ -45,7 +45,7 @@ async def create_twitter_account(skill, username: str, email: str,
             if await name_field.count() > 0:
                 await name_field.fill(display_name)
                 status = "name_filled"
-        except:
+        except Exception:
             pass
 
         try:
@@ -53,7 +53,7 @@ async def create_twitter_account(skill, username: str, email: str,
             if await email_field.count() > 0:
                 await email_field.fill(email)
                 status = "email_filled"
-        except:
+        except Exception:
             pass
 
         await asyncio.sleep(1)
@@ -84,7 +84,7 @@ async def create_twitter_account(skill, username: str, email: str,
                     await next_btn.click()
                     await asyncio.sleep(2)
                     status = "next_clicked"
-            except:
+            except Exception:
                 break
 
         # Step 6: Click "Sign up" to trigger CAPTCHA
@@ -94,7 +94,7 @@ async def create_twitter_account(skill, username: str, email: str,
                 await signup_btn.click()
                 await asyncio.sleep(5)
                 status = "signup_clicked"
-        except:
+        except Exception:
             pass
 
         # Step 7: Extract and solve FunCaptcha
@@ -151,7 +151,7 @@ async def create_twitter_account(skill, username: str, email: str,
                     try:
                         await inp.fill(code)
                         break
-                    except:
+                    except Exception:
                         continue
                 await asyncio.sleep(1)
                 try:
@@ -160,7 +160,7 @@ async def create_twitter_account(skill, username: str, email: str,
                         await next_btn.click()
                         await asyncio.sleep(3)
                         status = "email_verified"
-                except:
+                except Exception:
                     pass
 
         # Step 9: Set password if prompted
@@ -174,7 +174,7 @@ async def create_twitter_account(skill, username: str, email: str,
                     await next_btn.click()
                     await asyncio.sleep(3)
                     status = "password_set"
-        except:
+        except Exception:
             pass
 
         # Check final status

--- a/singularity/skills/builtin/agent_setup/supabase_browser.py
+++ b/singularity/skills/builtin/agent_setup/supabase_browser.py
@@ -73,7 +73,7 @@ async def browser_signup(agent_email: str, supabase_password: str,
         except Exception as e:
             try:
                 await page.screenshot(path="screenshots/supabase_error.png")
-            except:
+            except Exception:
                 pass
             await context.close()
             result["error"] = str(e)
@@ -94,14 +94,14 @@ async def _do_signup(page, email: str, password: str):
             if await page.query_selector(s):
                 await page.fill(s, email)
                 break
-        except:
+        except Exception:
             continue
     for s in ['input[type="password"]', 'input[name="password"]', '#password']:
         try:
             if await page.query_selector(s):
                 await page.fill(s, password)
                 break
-        except:
+        except Exception:
             continue
     for s in ['button[type="submit"]', 'button:has-text("Sign up")',
               'button:has-text("Sign Up")', 'button:has-text("Create account")']:
@@ -110,7 +110,7 @@ async def _do_signup(page, email: str, password: str):
             if btn:
                 await btn.click()
                 break
-        except:
+        except Exception:
             continue
     await asyncio.sleep(3)
 
@@ -168,14 +168,14 @@ async def _try_sign_in(page, email: str, password: str):
             if await page.query_selector(s):
                 await page.fill(s, email)
                 break
-        except:
+        except Exception:
             continue
     for s in ['input[type="password"]', 'input[name="password"]']:
         try:
             if await page.query_selector(s):
                 await page.fill(s, password)
                 break
-        except:
+        except Exception:
             continue
     for s in ['button[type="submit"]', 'button:has-text("Sign in")',
               'button:has-text("Sign In")']:
@@ -184,7 +184,7 @@ async def _try_sign_in(page, email: str, password: str):
             if btn:
                 await btn.click()
                 break
-        except:
+        except Exception:
             continue
     await asyncio.sleep(3)
 

--- a/singularity/skills/builtin/captcha/ai_vision.py
+++ b/singularity/skills/builtin/captcha/ai_vision.py
@@ -118,11 +118,11 @@ async def solve_recaptcha_in_iframe(solver, page, max_attempts=5) -> SkillResult
 
 async def _ev(frame, script):
     try: return await frame.evaluate(script)
-    except: return None
+    except Exception: return None
 
 async def _relocate_bframe(handle, frame, parent):
     try: await frame.evaluate('()=>1'); return handle, frame
-    except: pass
+    except Exception: pass
     h = await parent.query_selector('iframe[src*="bframe"]')
     if h:
         f = await h.content_frame()
@@ -132,15 +132,15 @@ async def _relocate_bframe(handle, frame, parent):
 async def _bframe_screenshot(handle, page) -> Optional[str]:
     try:
         try: await handle.scroll_into_view_if_needed()
-        except: pass
+        except Exception: pass
         await asyncio.sleep(0.5)
         return base64.standard_b64encode(await handle.screenshot()).decode('utf-8')
-    except:
+    except Exception:
         try:
             box = await handle.bounding_box()
             if box and page:
                 return base64.standard_b64encode(await page.screenshot(clip=box)).decode('utf-8')
-        except: pass
+        except Exception: pass
     return None
 
 async def _grid_size(bframe) -> int:
@@ -162,7 +162,7 @@ async def _find_bframe(page):
                 for inner in await of.query_selector_all('iframe'):
                     src = await inner.get_attribute('src') or ''
                     if 'bframe' in src: return await inner.content_frame(), inner
-        except: continue
+        except Exception: continue
     return None, None
 
 async def _check_solved(page) -> Optional[str]:
@@ -208,7 +208,7 @@ def _parse_positions(answer: str) -> Optional[List]:
     try:
         p = json.loads(answer)
         if isinstance(p, list) and all(isinstance(x, int) for x in p): return p
-    except: pass
+    except (json.JSONDecodeError, ValueError, TypeError): pass
     nums = [int(x) for x in re.findall(r'\d+', answer)]
     return nums if nums else None
 

--- a/singularity/skills/builtin/tiktok/__init__.py
+++ b/singularity/skills/builtin/tiktok/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from skills.base import Skill, SkillAction, SkillManifest, SkillResult
+from singularity.skills.base import Skill, SkillAction, SkillManifest, SkillResult
 from . import handlers
 
 SCRAPING_PATH = Path(__file__).parent.parent.parent.parent.parent.parent / "scraping" / "tiktok"
@@ -105,7 +105,7 @@ class TikTokSkill(Skill):
             }
             handler = dispatch.get(action)
             if not handler:
-                return SkillResult(success=False, error=f"Unknown action: {action}")
+                return SkillResult(success=False, message=f"Unknown action: {action}")
             return await handler()
         except Exception as e:
-            return SkillResult(success=False, error=str(e))
+            return SkillResult(success=False, message=str(e))

--- a/singularity/skills/builtin/tiktok/handlers.py
+++ b/singularity/skills/builtin/tiktok/handlers.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from typing import Dict, Any
-from skills.base import SkillResult
+from singularity.skills.base import SkillResult
 
 
 def _video_summary(v, fields=("video_id", "url", "author", "views", "caption", "hashtags")):
@@ -82,7 +82,7 @@ async def get_scail_videos(skill, params: Dict[str, Any]) -> SkillResult:
              "views": v.get("views", 0), "duration": v.get("duration_seconds"),
              "local_path": v.get("local_video_path")} for v in videos]})
     except Exception as e:
-        return SkillResult(success=False, error=str(e))
+        return SkillResult(success=False, message=str(e))
 
 
 async def get_trending_hashtags(skill, params: Dict[str, Any]) -> SkillResult:
@@ -112,7 +112,7 @@ async def analyze_hooks(skill, params: Dict[str, Any]) -> SkillResult:
         report = extractor.generate_hook_report()
         return SkillResult(success=True, data={"report": report})
     except Exception as e:
-        return SkillResult(success=False, error=str(e))
+        return SkillResult(success=False, message=str(e))
 
 
 async def get_stats(skill, params: Dict[str, Any]) -> SkillResult:
@@ -132,7 +132,7 @@ async def get_stats(skill, params: Dict[str, Any]) -> SkillResult:
                       "scail_ready_total": file_stats.get("scail_ready_total", 0),
                       "by_type": file_stats.get("scail_ready_by_type", {})}})
     except Exception as e:
-        return SkillResult(success=False, error=str(e))
+        return SkillResult(success=False, message=str(e))
 
 
 async def close(skill, params: Dict[str, Any]) -> SkillResult:


### PR DESCRIPTION
## Summary
- **Fix TikTok skill broken imports**: `skills.base` → `singularity.skills.base` in `__init__.py` and `handlers.py`. The skill was completely non-functional due to `ImportError`.
- **Fix TikTok SkillResult usage**: `error=` → `message=` parameter (5 occurrences). `SkillResult` dataclass has no `error` field, only `message`.
- **Replace 22 bare `except:` clauses** with `except Exception:` across 3 skill files (twitter.py, supabase_browser.py, ai_vision.py). Bare excepts catch `SystemExit` and `KeyboardInterrupt`, preventing graceful shutdown and hiding bugs. Aligns with ruff E722.

## Files Changed (5 files, 30 insertions, 30 deletions)
- `singularity/skills/builtin/tiktok/__init__.py` — import fix + `error=` → `message=`
- `singularity/skills/builtin/tiktok/handlers.py` — import fix + `error=` → `message=`
- `singularity/skills/builtin/account_creator/twitter.py` — 9 bare except fixes
- `singularity/skills/builtin/agent_setup/supabase_browser.py` — 7 bare except fixes
- `singularity/skills/builtin/captcha/ai_vision.py` — 6 bare except fixes

## Test plan
- [x] All changes are mechanical (import paths, parameter names, exception types)
- [x] No behavior changes — same exception handling, just more specific
- [x] Verified `SkillResult` dataclass only has `message` field, not `error`
- [x] Verified no other skills use `from skills.base import`

🤖 Generated with [Claude Code](https://claude.com/claude-code)