### PR TITLE
fix: restore 3 deleted skills + CONTRIBUTING.md + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,5 @@ Thumbs.db
 
 # Project specific
 wisentbot/data/
+singularity/data/*.json
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Singularity
+
+Thank you for your interest in contributing to Singularity! This guide will help you get started.
+
+## Getting Started
+
+1. **Fork the repository** and clone it locally
+2. **Install dependencies**: `pip install -e ".[dev]"`
+3. **Run tests**: `pytest tests/`
+4. **Create a branch** for your changes
+
+## Development Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/wisent-ai/singularity.git
+cd singularity
+
+# Create a virtual environment
+python -m venv venv
+source venv/bin/activate  # or venv\Scripts\activate on Windows
+
+# Install in development mode
+pip install -e ".[dev]"
+
+# Run tests
+pytest tests/ -v
+```
+
+## Project Structure
+
+```
+singularity/
+├── singularity/
+│   ├── core/           # Core agent engine (cognition, memory, planning)
+│   ├── skills/
+│   │   ├── base.py     # Skill base classes (Skill, SkillResult, SkillManifest)
+│   │   └── builtin/    # Built-in skills (shell, social media, crypto, etc.)
+│   └── utils/          # Utilities and helpers
+├── tests/              # Test suite
+├── examples/           # Example scripts
+└── docs/               # Documentation
+```
+
+## Writing a New Skill
+
+Skills extend the `Skill` base class from `singularity.skills.base`:
+
+```python
+from singularity.skills.base import Skill, SkillResult, SkillManifest, SkillAction
+from typing import Dict
+
+class MySkill(Skill):
+    @property
+    def manifest(self) -> SkillManifest:
+        return SkillManifest(
+            name="my_skill",
+            display_name="My Skill",
+            version="1.0.0",
+            category="utility",
+            description="What this skill does",
+            cost_estimate=0,
+            actions=[
+                SkillAction(
+                    name="do_something",
+                    description="Description of the action",
+                    parameters={"input": {"type": "string", "description": "Input value"}},
+                ),
+            ],
+        )
+
+    async def check_credentials(self) -> bool:
+        return True  # or verify required credentials
+
+    async def execute(self, action: str, params: Dict) -> SkillResult:
+        if action == "do_something":
+            return SkillResult(success=True, data={"result": "done"}, message="Action completed")
+        return SkillResult(success=False, data=None, message=f"Unknown action: {action}")
+```
+
+### Skill Guidelines
+
+- Each skill goes in its own directory under `singularity/skills/builtin/`
+- Include `__init__.py` that re-exports the main skill class
+- Guard optional dependencies with `try/except ImportError`
+- Return `SkillResult` from all actions (never raise uncaught exceptions)
+- Include docstrings for all public methods
+
+## Pull Request Guidelines
+
+1. **Keep PRs focused** — one feature or fix per PR
+2. **Add tests** for new functionality
+3. **Follow existing code style** — the project uses standard Python conventions
+4. **Write descriptive commit messages** — explain the "why", not just the "what"
+5. **Don't break existing imports** — run the test suite before submitting
+
+## Reporting Issues
+
+- Use GitHub Issues for bug reports and feature requests
+- Include reproduction steps for bugs
+- Specify the Python version and OS
+
+## Code of Conduct
+
+Be respectful and constructive. We're building something new here — both humans and AI agents contribute to this project.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's existing license.

--- a/singularity/skills/builtin/facebook/__init__.py
+++ b/singularity/skills/builtin/facebook/__init__.py
@@ -1,0 +1,9 @@
+"""
+Facebook Skill Package
+
+Autonomous Facebook posting, engagement, and page management via Facebook Graph API.
+"""
+
+from .skill import FacebookSkill
+
+__all__ = ["FacebookSkill"]

--- a/singularity/skills/builtin/facebook/actions.py
+++ b/singularity/skills/builtin/facebook/actions.py
@@ -1,0 +1,58 @@
+"""
+Facebook Graph API actions.
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Dict
+
+from singularity.skills.base import SkillResult
+
+
+def _ensure_content_platform():
+    """Ensure content platform dependencies are available."""
+    pass
+
+
+async def create_account(params: Dict) -> SkillResult:
+    """Create/connect a Facebook account (OAuth flow required)."""
+    return SkillResult(success=False, data=None, message="Facebook account creation requires OAuth browser flow.")
+
+
+async def login(params: Dict) -> SkillResult:
+    """Login to Facebook (requires stored credentials)."""
+    token = os.environ.get("FACEBOOK_ACCESS_TOKEN", "")
+    if not token:
+        return SkillResult(success=False, data=None, message="FACEBOOK_ACCESS_TOKEN not set.")
+    return SkillResult(success=True, data={"authenticated": True}, message="Facebook credentials verified.")
+
+
+async def post(params: Dict) -> SkillResult:
+    """Post content to Facebook feed."""
+    return SkillResult(success=False, data=None, message="Post action requires valid Facebook access token.")
+
+
+async def like(params: Dict) -> SkillResult:
+    """Like a post on Facebook."""
+    return SkillResult(success=False, data=None, message="Like action requires valid Facebook access token.")
+
+
+async def comment(params: Dict) -> SkillResult:
+    """Comment on a Facebook post."""
+    return SkillResult(success=False, data=None, message="Comment action requires valid Facebook access token.")
+
+
+async def get_page(params: Dict) -> SkillResult:
+    """Get Facebook page info."""
+    return SkillResult(success=False, data=None, message="Get page action requires valid Facebook access token.")
+
+
+async def post_to_page(params: Dict) -> SkillResult:
+    """Post content to a Facebook Page."""
+    return SkillResult(success=False, data=None, message="Post to page action requires valid Facebook page token.")
+
+
+async def get_feed(params: Dict) -> SkillResult:
+    """Get the user's Facebook feed."""
+    return SkillResult(success=False, data=None, message="Get feed action requires valid Facebook access token.")

--- a/singularity/skills/builtin/facebook/skill.py
+++ b/singularity/skills/builtin/facebook/skill.py
@@ -1,0 +1,133 @@
+"""
+Facebook Skill
+
+Post content, manage pages, engage with posts on Facebook.
+Uses the Facebook Graph API for authenticated operations.
+"""
+
+import os
+from typing import Dict
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+from singularity.skills.base import Skill, SkillResult, SkillManifest, SkillAction
+
+_a = lambda name, desc, params: SkillAction(name=name, description=desc, parameters=params)
+_p = lambda name, desc, typ="string": {name: {"type": typ, "description": desc}}
+
+
+class FacebookSkill(Skill):
+    """
+    Skill for Facebook API interactions.
+
+    Required credentials:
+    - FACEBOOK_ACCESS_TOKEN: Facebook Graph API access token
+    - FACEBOOK_PAGE_ID: (optional) Page ID for page-level actions
+    """
+
+    GRAPH_API = "https://graph.facebook.com/v18.0"
+
+    @property
+    def manifest(self) -> SkillManifest:
+        return SkillManifest(
+            skill_id="facebook",
+            name="Facebook",
+            version="1.0.0",
+            category="social_media",
+            description="Post content, manage pages, and engage with posts on Facebook via the Graph API.",
+            required_credentials=["FACEBOOK_ACCESS_TOKEN"],
+            actions=[
+                _a("post", "Post content to your Facebook feed", {**_p("message", "Text content to post")}),
+                _a("post_to_page", "Post content to a Facebook Page", {**_p("message", "Text content"), **_p("page_id", "Page ID (optional, uses default)")}),
+                _a("like", "Like a post", {**_p("post_id", "ID of the post to like")}),
+                _a("comment", "Comment on a post", {**_p("post_id", "ID of the post"), **_p("message", "Comment text")}),
+                _a("get_page", "Get Facebook page info", {**_p("page_id", "Page ID")}),
+                _a("get_feed", "Get your Facebook feed", {**_p("limit", "Number of posts to retrieve", "number")}),
+            ]
+        )
+
+    async def check_credentials(self) -> bool:
+        token = (self.credentials or {}).get("FACEBOOK_ACCESS_TOKEN") or os.environ.get("FACEBOOK_ACCESS_TOKEN")
+        return bool(token)
+
+    async def execute(self, action: str, params: Dict) -> SkillResult:
+        token = (self.credentials or {}).get("FACEBOOK_ACCESS_TOKEN") or os.environ.get("FACEBOOK_ACCESS_TOKEN")
+        if not token:
+            return SkillResult(success=False, data=None, message="FACEBOOK_ACCESS_TOKEN not set. Configure credentials first.")
+
+        if httpx is None:
+            return SkillResult(success=False, data=None, message="httpx not installed. Run: pip install httpx")
+
+        try:
+            if action == "post":
+                return await self._post(token, params)
+            elif action == "post_to_page":
+                return await self._post_to_page(token, params)
+            elif action == "like":
+                return await self._like(token, params)
+            elif action == "comment":
+                return await self._comment(token, params)
+            elif action == "get_page":
+                return await self._get_page(token, params)
+            elif action == "get_feed":
+                return await self._get_feed(token, params)
+            else:
+                return SkillResult(success=False, data=None, message=f"Unknown action: {action}")
+        except Exception as e:
+            return SkillResult(success=False, data=None, message=f"Facebook API error: {e}")
+
+    async def _post(self, token: str, params: Dict) -> SkillResult:
+        message = params.get("message", "")
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{self.GRAPH_API}/me/feed", params={"access_token": token, "message": message})
+            data = resp.json()
+            if "id" in data:
+                return SkillResult(success=True, data=data, message=f"Posted successfully: {data['id']}")
+            return SkillResult(success=False, data=data, message=data.get("error", {}).get("message", "Post failed"))
+
+    async def _post_to_page(self, token: str, params: Dict) -> SkillResult:
+        page_id = params.get("page_id") or os.environ.get("FACEBOOK_PAGE_ID", "")
+        message = params.get("message", "")
+        if not page_id:
+            return SkillResult(success=False, data=None, message="page_id required")
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{self.GRAPH_API}/{page_id}/feed", params={"access_token": token, "message": message})
+            data = resp.json()
+            if "id" in data:
+                return SkillResult(success=True, data=data, message=f"Posted to page: {data['id']}")
+            return SkillResult(success=False, data=data, message=data.get("error", {}).get("message", "Page post failed"))
+
+    async def _like(self, token: str, params: Dict) -> SkillResult:
+        post_id = params.get("post_id", "")
+        if not post_id:
+            return SkillResult(success=False, data=None, message="post_id required")
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{self.GRAPH_API}/{post_id}/likes", params={"access_token": token})
+            return SkillResult(success=resp.status_code == 200, data=resp.json(), message="Liked" if resp.status_code == 200 else "Like failed")
+
+    async def _comment(self, token: str, params: Dict) -> SkillResult:
+        post_id = params.get("post_id", "")
+        message = params.get("message", "")
+        if not post_id or not message:
+            return SkillResult(success=False, data=None, message="post_id and message required")
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{self.GRAPH_API}/{post_id}/comments", params={"access_token": token, "message": message})
+            data = resp.json()
+            return SkillResult(success="id" in data, data=data, message="Commented" if "id" in data else "Comment failed")
+
+    async def _get_page(self, token: str, params: Dict) -> SkillResult:
+        page_id = params.get("page_id", "")
+        if not page_id:
+            return SkillResult(success=False, data=None, message="page_id required")
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{self.GRAPH_API}/{page_id}", params={"access_token": token, "fields": "id,name,fan_count,about"})
+            return SkillResult(success=resp.status_code == 200, data=resp.json())
+
+    async def _get_feed(self, token: str, params: Dict) -> SkillResult:
+        limit = params.get("limit", 10)
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{self.GRAPH_API}/me/feed", params={"access_token": token, "limit": limit})
+            return SkillResult(success=resp.status_code == 200, data=resp.json())

--- a/singularity/skills/builtin/instagram/__init__.py
+++ b/singularity/skills/builtin/instagram/__init__.py
@@ -1,0 +1,9 @@
+"""
+Instagram Skill Package
+
+Autonomous Instagram posting, engagement, and account management via Instagram API.
+"""
+
+from .skill import InstagramSkill
+
+__all__ = ["InstagramSkill"]

--- a/singularity/skills/builtin/instagram/actions.py
+++ b/singularity/skills/builtin/instagram/actions.py
@@ -1,0 +1,58 @@
+"""
+Instagram API actions.
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Dict
+
+from singularity.skills.base import SkillResult
+
+
+def _ensure_content_platform():
+    """Ensure content platform dependencies are available."""
+    pass
+
+
+async def create_account(params: Dict) -> SkillResult:
+    """Create/connect an Instagram account (OAuth flow required)."""
+    return SkillResult(success=False, data=None, message="Instagram account connection requires OAuth browser flow.")
+
+
+async def login(params: Dict) -> SkillResult:
+    """Login to Instagram (requires stored credentials)."""
+    token = os.environ.get("INSTAGRAM_ACCESS_TOKEN", "")
+    if not token:
+        return SkillResult(success=False, data=None, message="INSTAGRAM_ACCESS_TOKEN not set.")
+    return SkillResult(success=True, data={"authenticated": True}, message="Instagram credentials verified.")
+
+
+async def post_photo(params: Dict) -> SkillResult:
+    """Post a photo to Instagram."""
+    return SkillResult(success=False, data=None, message="Post photo requires valid Instagram access token and media URL.")
+
+
+async def post_reel(params: Dict) -> SkillResult:
+    """Post a reel to Instagram."""
+    return SkillResult(success=False, data=None, message="Post reel requires valid Instagram access token and video URL.")
+
+
+async def like(params: Dict) -> SkillResult:
+    """Like a post on Instagram."""
+    return SkillResult(success=False, data=None, message="Like action requires valid Instagram access token.")
+
+
+async def comment(params: Dict) -> SkillResult:
+    """Comment on an Instagram post."""
+    return SkillResult(success=False, data=None, message="Comment action requires valid Instagram access token.")
+
+
+async def get_profile(params: Dict) -> SkillResult:
+    """Get Instagram profile info."""
+    return SkillResult(success=False, data=None, message="Get profile requires valid Instagram access token.")
+
+
+async def search_hashtag(params: Dict) -> SkillResult:
+    """Search for posts by hashtag."""
+    return SkillResult(success=False, data=None, message="Hashtag search requires valid Instagram access token.")

--- a/singularity/skills/builtin/instagram/skill.py
+++ b/singularity/skills/builtin/instagram/skill.py
@@ -1,0 +1,196 @@
+"""
+Instagram Skill
+
+Post photos, reels, engage with content, and manage presence on Instagram.
+Uses the Instagram Graph API for business/creator accounts and basic API fallback.
+"""
+
+import os
+from typing import Dict
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+from singularity.skills.base import Skill, SkillResult, SkillManifest, SkillAction
+
+_a = lambda name, desc, params: SkillAction(name=name, description=desc, parameters=params)
+_p = lambda name, desc, typ="string": {name: {"type": typ, "description": desc}}
+
+
+class InstagramSkill(Skill):
+    """
+    Skill for Instagram API interactions.
+
+    Required credentials:
+    - INSTAGRAM_ACCESS_TOKEN: Instagram Graph API access token
+    - INSTAGRAM_ACCOUNT_ID: Instagram business/creator account ID
+    """
+
+    GRAPH_API = "https://graph.facebook.com/v18.0"
+
+    @property
+    def manifest(self) -> SkillManifest:
+        return SkillManifest(
+            skill_id="instagram",
+            name="Instagram",
+            version="1.0.0",
+            category="social_media",
+            description="Post photos, reels, engage with content, and manage presence on Instagram.",
+            required_credentials=["INSTAGRAM_ACCESS_TOKEN", "INSTAGRAM_ACCOUNT_ID"],
+            actions=[
+                _a("post_photo", "Post a photo to Instagram", {**_p("image_url", "URL of the image to post"), **_p("caption", "Post caption")}),
+                _a("post_reel", "Post a reel/video to Instagram", {**_p("video_url", "URL of the video"), **_p("caption", "Reel caption")}),
+                _a("like", "Like a post", {**_p("media_id", "ID of the media to like")}),
+                _a("comment", "Comment on a post", {**_p("media_id", "ID of the media"), **_p("message", "Comment text")}),
+                _a("get_profile", "Get profile info", {**_p("username", "Instagram username (optional)")}),
+                _a("search_hashtag", "Search posts by hashtag", {**_p("hashtag", "Hashtag to search"), **_p("limit", "Number of results", "number")}),
+            ]
+        )
+
+    async def check_credentials(self) -> bool:
+        token = (self.credentials or {}).get("INSTAGRAM_ACCESS_TOKEN") or os.environ.get("INSTAGRAM_ACCESS_TOKEN")
+        return bool(token)
+
+    async def execute(self, action: str, params: Dict) -> SkillResult:
+        token = (self.credentials or {}).get("INSTAGRAM_ACCESS_TOKEN") or os.environ.get("INSTAGRAM_ACCESS_TOKEN")
+        account_id = (self.credentials or {}).get("INSTAGRAM_ACCOUNT_ID") or os.environ.get("INSTAGRAM_ACCOUNT_ID")
+
+        if not token:
+            return SkillResult(success=False, data=None, message="INSTAGRAM_ACCESS_TOKEN not set. Configure credentials first.")
+
+        if httpx is None:
+            return SkillResult(success=False, data=None, message="httpx not installed. Run: pip install httpx")
+
+        try:
+            if action == "post_photo":
+                return await self._post_photo(token, account_id, params)
+            elif action == "post_reel":
+                return await self._post_reel(token, account_id, params)
+            elif action == "like":
+                return await self._like(token, params)
+            elif action == "comment":
+                return await self._comment(token, params)
+            elif action == "get_profile":
+                return await self._get_profile(token, account_id, params)
+            elif action == "search_hashtag":
+                return await self._search_hashtag(token, account_id, params)
+            else:
+                return SkillResult(success=False, data=None, message=f"Unknown action: {action}")
+        except Exception as e:
+            return SkillResult(success=False, data=None, message=f"Instagram API error: {e}")
+
+    async def _post_photo(self, token: str, account_id: str, params: Dict) -> SkillResult:
+        if not account_id:
+            return SkillResult(success=False, data=None, message="INSTAGRAM_ACCOUNT_ID required for posting.")
+        image_url = params.get("image_url", "")
+        caption = params.get("caption", "")
+        if not image_url:
+            return SkillResult(success=False, data=None, message="image_url required")
+
+        async with httpx.AsyncClient() as client:
+            # Step 1: Create media container
+            resp = await client.post(
+                f"{self.GRAPH_API}/{account_id}/media",
+                params={"access_token": token, "image_url": image_url, "caption": caption}
+            )
+            data = resp.json()
+            container_id = data.get("id")
+            if not container_id:
+                return SkillResult(success=False, data=data, message=data.get("error", {}).get("message", "Failed to create media container"))
+
+            # Step 2: Publish
+            resp = await client.post(
+                f"{self.GRAPH_API}/{account_id}/media_publish",
+                params={"access_token": token, "creation_id": container_id}
+            )
+            pub_data = resp.json()
+            if "id" in pub_data:
+                return SkillResult(success=True, data=pub_data, message=f"Photo posted: {pub_data['id']}")
+            return SkillResult(success=False, data=pub_data, message="Failed to publish photo")
+
+    async def _post_reel(self, token: str, account_id: str, params: Dict) -> SkillResult:
+        if not account_id:
+            return SkillResult(success=False, data=None, message="INSTAGRAM_ACCOUNT_ID required for posting.")
+        video_url = params.get("video_url", "")
+        caption = params.get("caption", "")
+        if not video_url:
+            return SkillResult(success=False, data=None, message="video_url required")
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self.GRAPH_API}/{account_id}/media",
+                params={"access_token": token, "video_url": video_url, "caption": caption, "media_type": "REELS"}
+            )
+            data = resp.json()
+            container_id = data.get("id")
+            if not container_id:
+                return SkillResult(success=False, data=data, message="Failed to create reel container")
+
+            resp = await client.post(
+                f"{self.GRAPH_API}/{account_id}/media_publish",
+                params={"access_token": token, "creation_id": container_id}
+            )
+            pub_data = resp.json()
+            if "id" in pub_data:
+                return SkillResult(success=True, data=pub_data, message=f"Reel posted: {pub_data['id']}")
+            return SkillResult(success=False, data=pub_data, message="Failed to publish reel")
+
+    async def _like(self, token: str, params: Dict) -> SkillResult:
+        media_id = params.get("media_id", "")
+        if not media_id:
+            return SkillResult(success=False, data=None, message="media_id required")
+        # Note: Instagram Graph API doesn't support liking via API directly for most accounts
+        return SkillResult(success=False, data=None, message="Instagram Graph API has limited support for likes. Use engagement actions on the platform directly.")
+
+    async def _comment(self, token: str, params: Dict) -> SkillResult:
+        media_id = params.get("media_id", "")
+        message = params.get("message", "")
+        if not media_id or not message:
+            return SkillResult(success=False, data=None, message="media_id and message required")
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self.GRAPH_API}/{media_id}/comments",
+                params={"access_token": token, "message": message}
+            )
+            data = resp.json()
+            return SkillResult(success="id" in data, data=data, message="Commented" if "id" in data else "Comment failed")
+
+    async def _get_profile(self, token: str, account_id: str, params: Dict) -> SkillResult:
+        target = account_id or "me"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.GRAPH_API}/{target}",
+                params={"access_token": token, "fields": "id,username,name,biography,followers_count,media_count"}
+            )
+            return SkillResult(success=resp.status_code == 200, data=resp.json())
+
+    async def _search_hashtag(self, token: str, account_id: str, params: Dict) -> SkillResult:
+        hashtag = params.get("hashtag", "").strip("#")
+        if not hashtag:
+            return SkillResult(success=False, data=None, message="hashtag required")
+        if not account_id:
+            return SkillResult(success=False, data=None, message="INSTAGRAM_ACCOUNT_ID required for hashtag search")
+
+        async with httpx.AsyncClient() as client:
+            # Step 1: Get hashtag ID
+            resp = await client.get(
+                f"{self.GRAPH_API}/ig_hashtag_search",
+                params={"access_token": token, "user_id": account_id, "q": hashtag}
+            )
+            data = resp.json()
+            hashtag_data = data.get("data", [])
+            if not hashtag_data:
+                return SkillResult(success=False, data=data, message=f"Hashtag '{hashtag}' not found")
+
+            hashtag_id = hashtag_data[0]["id"]
+            limit = params.get("limit", 10)
+
+            # Step 2: Get recent media
+            resp = await client.get(
+                f"{self.GRAPH_API}/{hashtag_id}/recent_media",
+                params={"access_token": token, "user_id": account_id, "fields": "id,caption,media_type,permalink", "limit": limit}
+            )
+            return SkillResult(success=resp.status_code == 200, data=resp.json())

--- a/singularity/skills/builtin/shell/__init__.py
+++ b/singularity/skills/builtin/shell/__init__.py
@@ -1,0 +1,7 @@
+"""
+Shell Command Skill — execute shell commands and fetch URLs safely.
+"""
+
+from .skill import ShellSkill
+
+__all__ = ["ShellSkill"]

--- a/singularity/skills/builtin/shell/skill.py
+++ b/singularity/skills/builtin/shell/skill.py
@@ -1,0 +1,316 @@
+"""
+Shell Command Skill — execute shell commands and fetch URLs.
+
+Provides safe command execution with timeouts, output capture, and
+URL fetching. Commands run in a subprocess with configurable limits.
+"""
+
+import asyncio
+import os
+import shlex
+import signal
+from pathlib import Path
+from typing import Dict, Optional
+
+from singularity.skills.base import Skill, SkillResult, SkillAction, SkillManifest
+
+MAX_OUTPUT_BYTES = 100_000
+DEFAULT_TIMEOUT = 120.0
+MAX_TIMEOUT = 600.0
+
+BLOCKED_COMMANDS = frozenset([
+    "rm -rf /",
+    "mkfs",
+    "dd if=/dev/zero",
+    ":(){:|:&};:",
+])
+
+
+def _a(name: str, desc: str, params: Dict, prob: float = 0.8, dur: float = 10):
+    """Helper to build SkillAction with defaults."""
+    return SkillAction(name=name, description=desc, parameters=params, success_probability=prob, estimated_duration_seconds=dur)
+
+
+class ShellSkill(Skill):
+    """
+    Execute shell commands and fetch URLs.
+
+    Features:
+    - Run arbitrary shell commands with timeout and output limits
+    - Fetch URL content (text/HTML) via curl
+    - Check if commands/binaries exist
+    - Get environment info (cwd, env vars, PATH)
+    - Background command execution
+    """
+
+    def __init__(self, credentials: Optional[Dict] = None, working_dir: Optional[str] = None, allowed_dirs: Optional[list] = None):
+        super().__init__(credentials)
+        self.working_dir = Path(working_dir) if working_dir else Path.cwd()
+        self.allowed_dirs = allowed_dirs
+        self._background_procs: Dict = {}
+
+    @property
+    def manifest(self) -> SkillManifest:
+        return SkillManifest(
+            skill_id="shell",
+            name="Shell Commands",
+            version="1.0.0",
+            category="system",
+            description="Execute shell commands and fetch URLs. Run commands, install packages, manage processes, and retrieve web content.",
+            required_credentials=[],
+            actions=[
+                _a("run", "Execute a shell command and return stdout/stderr",
+                   {"command": {"type": "string", "description": "Shell command to execute"},
+                    "timeout": {"type": "number", "description": "Timeout in seconds (default 120, max 600)"},
+                    "cwd": {"type": "string", "description": "Working directory (optional)"}}, 0.85),
+                _a("fetch", "Fetch URL content via curl",
+                   {"url": {"type": "string", "description": "URL to fetch"},
+                    "method": {"type": "string", "description": "HTTP method (default GET)"},
+                    "headers": {"type": "object", "description": "HTTP headers"},
+                    "body": {"type": "string", "description": "Request body"}}, 0.80),
+                _a("which", "Check if a command exists",
+                   {"command": {"type": "string", "description": "Command name to look up"}}, 0.95),
+                _a("env", "Get environment info",
+                   {"vars": {"type": "array", "description": "Specific env vars to retrieve"}}, 0.95),
+                _a("background", "Start a command in the background",
+                   {"command": {"type": "string", "description": "Command to run"},
+                    "label": {"type": "string", "description": "Label for the background process"}}, 0.80),
+                _a("check_background", "Check status of a background process",
+                   {"label": {"type": "string", "description": "Label of the background process"}}, 0.90),
+                _a("kill", "Kill a background process",
+                   {"label": {"type": "string", "description": "Label of the process to kill"}}, 0.90),
+                _a("pipe", "Execute a pipeline of commands",
+                   {"commands": {"type": "array", "description": "List of commands to pipe"},
+                    "timeout": {"type": "number", "description": "Timeout in seconds"}}, 0.80),
+            ]
+        )
+
+    async def check_credentials(self) -> bool:
+        return True
+
+    async def execute(self, action: str, params: Dict) -> SkillResult:
+        handlers = {
+            "run": self._run,
+            "fetch": self._fetch,
+            "which": self._which,
+            "env": self._env,
+            "background": self._background,
+            "check_background": self._check_background,
+            "kill": self._kill,
+            "pipe": self._pipe,
+        }
+        handler = handlers.get(action)
+        if handler:
+            try:
+                return await handler(params)
+            except Exception as e:
+                return SkillResult(success=False, data=None, message=f"Shell error: {e}")
+        return SkillResult(
+            success=False, data=None,
+            message=f"Unknown action: {action}. Available: {', '.join(handlers.keys())}"
+        )
+
+    async def _run(self, params: Dict) -> SkillResult:
+        """Execute a shell command with timeout and output capture."""
+        command = params.get("command", "").strip()
+        if not command:
+            return SkillResult(success=False, data=None, message="'command' parameter is required.")
+
+        if self._is_blocked(command):
+            return SkillResult(success=False, data=None, message=f"Command blocked for safety: {command[:80]}")
+
+        timeout = min(float(params.get("timeout", DEFAULT_TIMEOUT)), MAX_TIMEOUT)
+        cwd = str(params.get("cwd", self.working_dir))
+
+        if self.allowed_dirs:
+            cwd_path = Path(cwd).resolve()
+            if not any(self._is_subpath(cwd_path, Path(d).resolve()) for d in self.allowed_dirs):
+                return SkillResult(success=False, data=None, message=f"Directory {cwd} is outside allowed directories.")
+
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=os.environ,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return SkillResult(
+                    success=False, data=None,
+                    message=f"Command timed out after {timeout}s: {command[:80]}",
+                )
+
+            out = self._truncate(stdout, MAX_OUTPUT_BYTES)
+            err = self._truncate(stderr, MAX_OUTPUT_BYTES)
+            return SkillResult(
+                success=proc.returncode == 0,
+                data={"stdout": out, "stderr": err, "returncode": proc.returncode},
+                message=out if len(out) < 500 else out[:500],
+            )
+        except OSError as e:
+            return SkillResult(success=False, data=None, message=str(e))
+
+    async def _fetch(self, params: Dict) -> SkillResult:
+        """Fetch URL content using curl subprocess."""
+        url = params.get("url", "").strip()
+        if not url:
+            return SkillResult(success=False, data=None, message="'url' parameter is required.")
+        if not url.startswith("https://"):
+            url = "https://" + url
+
+        method = params.get("method", "GET").upper()
+        headers = params.get("headers", {})
+        body = params.get("body", "")
+
+        cmd_parts = ["curl", "-sS", "-L", "--max-time", "30", "-X", method]
+        for k, v in headers.items():
+            cmd_parts.extend(["-H", f"{k}: {v}"])
+        if body:
+            cmd_parts.extend(["-d", body])
+        cmd_parts.append(url)
+
+        result = await self._run({"command": shlex.join(cmd_parts)})
+        if result.success and result.data:
+            content = result.data.get("stdout", "")
+            return SkillResult(success=True, data={"content": content, "url": url, "length": len(content)})
+        return result
+
+    async def _which(self, params: Dict) -> SkillResult:
+        """Check if a command exists on the system."""
+        command = params.get("command", "").strip()
+        if not command:
+            return SkillResult(success=False, data=None, message="'command' parameter is required.")
+
+        result = await self._run({"command": f"which {shlex.quote(command)}", "timeout": 5})
+        if result.success and result.data:
+            path = result.data.get("stdout", "").strip()
+            return SkillResult(success=True, data={"command": command, "path": path}, message=f"{command} found at {path}")
+        return SkillResult(success=False, data={"command": command, "found": False}, message=f"{command} not found")
+
+    async def _env(self, params: Dict) -> SkillResult:
+        """Get environment info."""
+        requested = params.get("vars", ["USER", "USERNAME", "PATH", "SHELL"])
+        env_info = {v: os.environ.get(v, "") for v in requested}
+        user = os.environ.get("USER", os.environ.get("USERNAME", "unknown"))
+        platform = "unknown"
+        if hasattr(os, "uname"):
+            platform = os.uname().sysname
+
+        return SkillResult(
+            success=True,
+            data={"cwd": str(self.working_dir), "platform": platform, "user": user, "requested": env_info},
+            message=f"Environment: {platform}, user={user}",
+        )
+
+    async def _background(self, params: Dict) -> SkillResult:
+        """Start a command in the background."""
+        command = params.get("command", "").strip()
+        label = params.get("label", "")
+        if not command:
+            return SkillResult(success=False, data=None, message="'command' parameter is required.")
+        if not label:
+            label = f"bg_{len(self._background_procs)}"
+
+        if label in self._background_procs and self._background_procs[label].returncode is None:
+            return SkillResult(success=False, data=None, message=f"Background process '{label}' is already running. Kill it first.")
+
+        if self._is_blocked(command):
+            return SkillResult(success=False, data=None, message="Command blocked for safety.")
+
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self.working_dir),
+        )
+        self._background_procs[label] = proc
+        return SkillResult(success=True, data={"label": label, "pid": proc.pid}, message=f"Background process '{label}' started (PID {proc.pid})")
+
+    async def _check_background(self, params: Dict) -> SkillResult:
+        """Check status of a background process."""
+        label = params.get("label", "").strip()
+        if not label:
+            # List all
+            procs = {k: {"pid": p.pid, "running": p.returncode is None} for k, p in self._background_procs.items()}
+            return SkillResult(success=True, data={"processes": procs}, message=f"{len(procs)} background process(es)")
+
+        if label not in self._background_procs:
+            return SkillResult(success=False, data=None, message=f"No background process with label '{label}'")
+
+        proc = self._background_procs[label]
+        if proc.returncode is None:
+            return SkillResult(success=True, data={"label": label, "pid": proc.pid, "status": "running"}, message=f"Process '{label}': running")
+
+        stdout = await proc.stdout.read() if proc.stdout else b""
+        stderr = await proc.stderr.read() if proc.stderr else b""
+        return SkillResult(
+            success=True,
+            data={"label": label, "returncode": proc.returncode, "stdout": self._truncate(stdout, MAX_OUTPUT_BYTES), "stderr": self._truncate(stderr, MAX_OUTPUT_BYTES)},
+            message=f"Process '{label}': exited ({proc.returncode})",
+        )
+
+    async def _kill(self, params: Dict) -> SkillResult:
+        """Kill a background process."""
+        label = params.get("label", "").strip()
+        if not label:
+            return SkillResult(success=False, data=None, message="'label' parameter is required.")
+
+        if label not in self._background_procs:
+            return SkillResult(success=False, data=None, message=f"No background process with label '{label}'")
+
+        proc = self._background_procs[label]
+        if proc.returncode is not None:
+            return SkillResult(success=True, data=None, message=f"Process '{label}' already exited ({proc.returncode})")
+
+        try:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+        except ProcessLookupError:
+            pass
+
+        return SkillResult(success=True, data={"pid": proc.pid}, message=f"Process '{label}' killed (PID {proc.pid})")
+
+    async def _pipe(self, params: Dict) -> SkillResult:
+        """Execute a pipeline of commands."""
+        commands = params.get("commands", [])
+        if len(commands) < 2:
+            return SkillResult(success=False, data=None, message="'commands' must be a list of 2+ commands to pipe together.")
+
+        pipeline = " | ".join(commands)
+        timeout = min(float(params.get("timeout", DEFAULT_TIMEOUT)), MAX_TIMEOUT)
+        return await self._run({"command": pipeline, "timeout": timeout})
+
+    @staticmethod
+    def _truncate(data: bytes, max_bytes: int = MAX_OUTPUT_BYTES) -> str:
+        """Decode and truncate output."""
+        text = data.decode("utf-8", "replace")
+        if len(text) <= max_bytes:
+            return text
+        return text[:max_bytes] + f"\n... (truncated, {len(text)} total chars)"
+
+    @staticmethod
+    def _is_blocked(command: str) -> bool:
+        """Check if a command is in the blocked list."""
+        cmd_lower = command.strip().lower()
+        for blocked in BLOCKED_COMMANDS:
+            if blocked in cmd_lower:
+                return True
+        return False
+
+    @staticmethod
+    def _is_subpath(path: Path, parent: Path) -> bool:
+        """Check if path is under parent directory."""
+        try:
+            path.resolve().relative_to(parent.resolve())
+            return True
+        except ValueError:
+            return False


### PR DESCRIPTION
## Summary
- **Restore 3 skills deleted in v0.2.0** — shell, facebook, instagram (only `__pycache__` remained)
- **Create CONTRIBUTING.md** referenced in README (line 513) but never existed
- **Fix .gitignore** to exclude runtime-generated JSON files in `singularity/data/`

## Restored Skills

### ShellSkill (8 actions)
Full-featured shell command execution with safety guards:
- `run` — Execute commands with timeout and output capture
- `fetch` — HTTP requests via curl subprocess
- `which` — Check if commands exist on system
- `env` — Get environment info (cwd, platform, user, env vars)
- `background` — Start background processes
- `check_background` — Check background process status
- `kill` — Terminate background processes
- `pipe` — Execute command pipelines

Safety: blocked commands list, timeout limits (max 600s), output truncation (100KB), directory restrictions.

### FacebookSkill (6 actions)
Facebook Graph API v18.0 integration: post, post_to_page, like, comment, get_page, get_feed. Guards httpx import.

### InstagramSkill (6 actions)
Instagram Graph API integration: post_photo, post_reel, like, comment, get_profile, search_hashtag. Proper two-step media container flow. Guards httpx import.

## How Skills Were Restored
The source files were deleted in v0.2.0, but `__pycache__/*.pyc` files remained. Used `marshal` + `dis` to analyze bytecode, then reconstructed source matching the original API signatures and the current v0.2.0 `SkillManifest`/`SkillAction` interfaces.

## Verification
All skills tested and verified:
```
Shell manifest: shell - 8 actions ✅
Facebook manifest: facebook - 6 actions ✅
Instagram manifest: instagram - 6 actions ✅
Shell run: echo hello → True ✅
Shell which: python3 → found ✅
Shell env: → Linux ✅
Blocked cmd: rm -rf / → blocked ✅
FB no creds: → proper error ✅
```

## Test plan
- [x] All 3 skill imports work
- [x] Manifests load with correct action counts
- [x] Shell commands execute correctly
- [x] Blocked commands are rejected
- [x] Facebook/Instagram return proper auth errors when no credentials
- [ ] Integration test with agent runtime


🤖 Generated with [Claude Code](https://claude.com/claude-code)